### PR TITLE
Fix language dropdown hover

### DIFF
--- a/components/language-selector.tsx
+++ b/components/language-selector.tsx
@@ -54,8 +54,8 @@ export function LanguageSelector() {
             "transition-colors duration-150",
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           )}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
+          onPointerEnter={handleMouseEnter}
+          onPointerLeave={handleMouseLeave}
           ref={triggerRef}
           type="button"
         >
@@ -73,8 +73,8 @@ export function LanguageSelector() {
             "data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2"
           )}
           onCloseAutoFocus={preventCloseAutoFocus}
-          onMouseEnter={handleContentMouseEnter}
-          onMouseLeave={handleContentMouseLeave}
+          onPointerEnter={handleContentMouseEnter}
+          onPointerLeave={handleContentMouseLeave}
           ref={contentRef}
           sideOffset={5}
         >

--- a/shared/hooks/use-hover-dropdown.ts
+++ b/shared/hooks/use-hover-dropdown.ts
@@ -7,6 +7,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
 
 import { isPointInTriangle } from "@/shared/utils/geometry";
 
@@ -62,10 +63,10 @@ interface UseHoverDropdownOptions {
 
 interface UseHoverDropdownReturn {
   contentRef: React.RefObject<HTMLDivElement | null>;
-  handleContentMouseEnter: () => void;
-  handleContentMouseLeave: () => void;
-  handleMouseEnter: () => void;
-  handleMouseLeave: () => void;
+  handleContentMouseEnter: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleContentMouseLeave: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  handleMouseEnter: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  handleMouseLeave: (event: ReactPointerEvent<HTMLButtonElement>) => void;
   handleOpenChange: (open: boolean) => void;
   isOpen: boolean;
   isTouchDevice: boolean;
@@ -164,7 +165,7 @@ export function useHoverDropdown(
 
   // Handle mouse movement for safe triangle
   useEffect(() => {
-    if (!isOpen || isTouchDevice) {
+    if (!isOpen) {
       return;
     }
 
@@ -187,10 +188,10 @@ export function useHoverDropdown(
 
     document.addEventListener("mousemove", handleMouseMove);
     return () => document.removeEventListener("mousemove", handleMouseMove);
-  }, [isOpen, isTouchDevice]);
+  }, [isOpen]);
 
-  const handleMouseEnter = () => {
-    if (isTouchDevice) {
+  const handleMouseEnter = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === "touch") {
       return;
     }
 
@@ -209,8 +210,8 @@ export function useHoverDropdown(
     }
   };
 
-  const handleMouseLeave = () => {
-    if (isTouchDevice) {
+  const handleMouseLeave = (event: ReactPointerEvent<HTMLButtonElement>) => {
+    if (event.pointerType === "touch") {
       return;
     }
 
@@ -230,8 +231,10 @@ export function useHoverDropdown(
     }, closeDelay);
   };
 
-  const handleContentMouseEnter = () => {
-    if (isTouchDevice) {
+  const handleContentMouseEnter = (
+    event: ReactPointerEvent<HTMLDivElement>
+  ) => {
+    if (event.pointerType === "touch") {
       return;
     }
 
@@ -241,15 +244,17 @@ export function useHoverDropdown(
     }
   };
 
-  const handleContentMouseLeave = () => {
-    if (isTouchDevice) {
+  const handleContentMouseLeave = (
+    event: ReactPointerEvent<HTMLDivElement>
+  ) => {
+    if (event.pointerType === "touch") {
       return;
     }
 
     closeTimeoutRef.current = setTimeout(() => {
       setIsOpen(false);
       closeTimeoutRef.current = null;
-    }, openDelay);
+    }, closeDelay);
   };
 
   // Touch devices: allow click/keyboard to toggle. Desktop: ignore opens (hover only),


### PR DESCRIPTION
## Summary
- Open the language menu based on the active pointer type, so desktop hover works on touch-capable devices.
- Preserve touch activation while also supporting pen hover.
- Apply the configured close delay when the pointer leaves the menu.

## Root cause
The menu treated devices with any coarse pointer as touch-only, which disabled hover even when a mouse was present.

## Validation
- `pnpm test`
- `pnpm check:types`
- `pnpm check:oxlint`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the language selector so hover works with mouse and pen on touch-capable devices, while keeping touch tap behavior. Also applies the configured close delay when the pointer leaves the menu.

- **Bug Fixes**
  - Switched to `onPointerEnter`/`onPointerLeave` and gate hover by `event.pointerType !== "touch"`.
  - Updated `useHoverDropdown` handlers to accept `React.PointerEvent` and removed coarse-pointer gating; safe-triangle tracking now runs only when open.
  - Use `closeDelay` when leaving content (was using `openDelay`).

<sup>Written for commit acc7c43cbb16d1bf116aa2cf7e366525342bb8ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

