### PR TITLE
Fix desktop language dropdown

### DIFF
--- a/shared/hooks/use-hover-dropdown.test.tsx
+++ b/shared/hooks/use-hover-dropdown.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useHoverDropdown } from "./use-hover-dropdown";
+
+const noop = () => null;
+
+describe("desktop dropdown interactions", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: (query: string): MediaQueryList => ({
+        addEventListener: noop,
+        addListener: noop,
+        dispatchEvent: () => true,
+        matches: false,
+        media: query,
+        onchange: null,
+        removeEventListener: noop,
+        removeListener: noop,
+      }),
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", {
+      configurable: true,
+      value: 0,
+    });
+  });
+
+  it("opens from the dropdown trigger on desktop", () => {
+    const { result } = renderHook(() => useHoverDropdown());
+
+    act(() => result.current.handleOpenChange(true));
+
+    expect(result.current.isOpen).toBeTruthy();
+  });
+});

--- a/shared/hooks/use-hover-dropdown.ts
+++ b/shared/hooks/use-hover-dropdown.ts
@@ -95,36 +95,6 @@ export function useHoverDropdown(
   const openTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const closeTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isMouseInSafeZoneRef = useRef(false);
-  const lastInteractionRef = useRef<
-    "mouse" | "touch" | "pen" | "keyboard" | null
-  >(null);
-
-  // Track last interaction type for desktop keyboard access
-  useEffect(() => {
-    const handlePointerDown = (e: PointerEvent) => {
-      const pointerType =
-        e.pointerType === "mouse" ||
-        e.pointerType === "touch" ||
-        e.pointerType === "pen"
-          ? e.pointerType
-          : "mouse";
-      lastInteractionRef.current = pointerType;
-    };
-
-    const handleKeyDown = () => {
-      lastInteractionRef.current = "keyboard";
-    };
-
-    window.addEventListener("pointerdown", handlePointerDown, {
-      passive: true,
-    });
-    window.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      window.removeEventListener("pointerdown", handlePointerDown);
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, []);
 
   // Clear timeouts on unmount
   useEffect(
@@ -252,20 +222,10 @@ export function useHoverDropdown(
     }, openDelay);
   };
 
-  // Touch devices: allow click/keyboard to toggle. Desktop: ignore opens (hover only),
-  // but allow closes (outside click / Escape) and keyboard opens to be reflected.
+  // Keep Radix's click, touch, keyboard, outside-click, and Escape interactions
+  // in sync with the controlled state. Pointer hover is handled above.
   const handleOpenChange = (open: boolean) => {
-    if (isTouchDevice) {
-      setIsOpen(open);
-      return;
-    }
-    if (!open) {
-      setIsOpen(false);
-      return;
-    }
-    if (lastInteractionRef.current === "keyboard") {
-      setIsOpen(true);
-    }
+    setIsOpen(open);
   };
 
   return {


### PR DESCRIPTION
## What changed

- keep Radix dropdown open-state changes in sync on desktop clicks
- preserve the existing hover behavior
- remove the now-unnecessary global interaction tracking
- add a regression test for desktop trigger opens

## Why

The controlled dropdown ignored `open=true` events from mouse clicks on desktop, so the language selector button rendered but did not open its menu. The main page remains unchanged and does not show a language selector.

## Validation

- `pnpm check:types`
- `pnpm test` (29 tests passed)
- `pnpm exec ultracite check shared/hooks/use-hover-dropdown.ts shared/hooks/use-hover-dropdown.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop language dropdown not opening on click by syncing Radix `open` state in `useHoverDropdown`. Keeps hover behavior and ensures the trigger opens the menu on desktop.

- **Bug Fixes**
  - `handleOpenChange` now mirrors Radix open/close for click, touch, keyboard, outside-click, and Escape.
  - Removed global interaction tracking and desktop-specific guards.
  - Added a jsdom regression test to verify desktop trigger opens.

<sup>Written for commit 462ddf7c1af12f59a957b9ad5bd77db4a91d662c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/66?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

