### PR TITLE
Disable mismatched chunk integrity hashes

### DIFF
--- a/next.config.mts
+++ b/next.config.mts
@@ -16,7 +16,6 @@ const nextConfig: NextConfig = {
       "@react-three/fiber",
     ],
     prefetchInlining: true,
-    sri: { algorithm: "sha256" },
     turbopackFileSystemCacheForDev: true,
     viewTransition: true,
   },


### PR DESCRIPTION
## What changed

- disable Next.js's experimental Subresource Integrity configuration

## Why

The production HTML declared `sha256-saeQvzG2453f9W0dskHWbc3V/ZxZKf4z+llFtuRRZ5o=` for the Turbopack runtime chunk, while the bytes served by Vercel computed to `sha256-+NCe3kfYLcNwpAyxltrFtJc/TVd9gTWsDsOSh8/UbMU=`. Chrome correctly blocked the runtime chunk, preventing React hydration and leaving interactive controls such as the language dropdown non-functional.

Next.js currently marks this SRI option as experimental. Removing it prevents the browser from rejecting otherwise valid deployment chunks.

## User impact

Interactive client-side controls can hydrate and respond again in production.

## Validation

- `pnpm exec ultracite check next.config.mts`
- `pnpm check:types`
- `pnpm test` (29 tests passed)
- `pnpm build`
- confirmed generated `_next` scripts no longer contain integrity attributes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Next.js `experimental.sri` setting to avoid mismatched integrity hashes that were blocking the Turbopack runtime chunk. This restores React hydration and re-enables interactive controls in production.

<sup>Written for commit 7177c484621d640a52644abff293f1c09471d3e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/67?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

