### PR TITLE
Align cat position across pages

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -37,7 +37,7 @@ export default function Page() {
   const t = useTranslations();
 
   return (
-    <section className="home-page mx-auto flex w-full max-w-lg flex-1 flex-col pt-24 pb-12 sm:pt-[6.625rem]">
+    <section className="home-page mx-auto flex w-full max-w-lg flex-1 flex-col pt-[6.5rem] pb-12">
       <header className="mb-16">
         <Link
           aria-label="minpeter home"


### PR DESCRIPTION
## What changed

- use the same 6.5rem top spacing on the home page as the blog, showcase, and resume pages
- remove the home-only responsive top-spacing override

## Why

The home cat started at 96px on mobile and 106px on desktop, while the other cat-bearing pages consistently used 104px. During page crossfades this produced an 8px mobile ghost, a 2px desktop offset, and a 10px jump at the 640px breakpoint.

## User impact

The cat now occupies the exact same position across the relevant pages and remains stable as the viewport crosses the responsive breakpoint.

## Validation

- `pnpm exec ultracite check app/[locale]/page.tsx`
- `pnpm check:types`
- `pnpm test` (29 tests passed)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned the cat position across home, blog, showcase, and resume to prevent offset during crossfades and jumps at the sm breakpoint.

- **Bug Fixes**
  - Set home page top padding to `pt-[6.5rem]` to match other pages.
  - Removed the home-only `sm:pt` override to keep position consistent.
  - Eliminated the 8px mobile ghost, 2px desktop offset, and 10px jump at 640px.

<sup>Written for commit b404f65d228a6c98d7b3bb12c49d33bfcf6d6bd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

