### PR TITLE
Normalize cat logo size

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -559,6 +559,8 @@
   }
 
   .home-logo {
+    width: 2rem;
+    height: 2rem;
     transition: filter 300ms ease;
   }
 


### PR DESCRIPTION
## What changed

- explicitly size the home cat logo to 2rem by 2rem, matching the blog, showcase, and resume pages

## Why

Tailwind's image reset applies `height: auto`. The home logo had no height override, so its 118:104 SVG aspect ratio produced a 32 by 28.203125 pixel element. Other pages explicitly rendered a 32 by 32 pixel element. This left a visible size/vertical-content mismatch during page transitions even after the top coordinates were aligned.

## User impact

The cat now has identical coordinates and dimensions on every page at all tested viewport sizes.

## Validation

- Playwright layout scan: 604 route/viewport combinations
- alignment failures: 0
- invalid sizes: 0
- navigation overlaps: 0
- viewport overflows: 0
- `pnpm check:types`
- `pnpm test` (29 tests passed)
- `pnpm build`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the home cat logo to a fixed 2rem × 2rem to match the blog, showcase, and resume pages and remove size/position jitter during navigation. Adds explicit width and height on `.home-logo` to override Tailwind’s image reset.

<sup>Written for commit e5c84f0f42a9b69e685b68025c20585cde3ae636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

