### PR TITLE
Refresh showcase experiment pages

### DIFF
--- a/app/[locale]/show/dynamic-hacked-text/animated-text.tsx
+++ b/app/[locale]/show/dynamic-hacked-text/animated-text.tsx
@@ -55,7 +55,7 @@ export default function AnimatedText({ data }: { data: string }) {
 
   return (
     <button
-      className="cursor-pointer rounded font-bold text-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="cursor-pointer rounded-md px-3 py-2 font-mono font-medium text-2xl tracking-[-0.04em] sm:text-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       onFocus={handleMouseOver}
       onMouseOver={handleMouseOver}
       type="button"

--- a/app/[locale]/show/dynamic-hacked-text/page.tsx
+++ b/app/[locale]/show/dynamic-hacked-text/page.tsx
@@ -1,24 +1,32 @@
 import type { Route } from "next";
+import { getTranslations } from "next-intl/server";
 
-import Header from "@/components/header";
-import { cn } from "@/shared/utils/tailwind";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
 import AnimatedText from "./animated-text";
 
-import styles from "@/shared/styles/stagger-fade-in.module.css";
+export const metadata = NewMetadata({
+  description: "Hover over the letters and watch them react.",
+  title: "minpeter | dynamic hacked text",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/dynamic-hacked-text">
 ) {
-  const { locale } = await props.params;
+  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+
   return (
-    <section className="flex flex-col gap-3">
-      <Header
-        description="글자 위에 마우스를 가져다 놓아보세요"
-        link={{ href: `/${locale}/show` as Route, text: "showcase로 돌아가기" }}
-        title="/show/dynamic-hacked-text"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="Move across the letters and watch the text reconstruct itself."
+        href={`/${locale}/show` as Route}
+        kicker="Interaction study"
+        title="Dynamic hacked text"
       />
-      <div className={cn(styles.stagger_container, styles.slow)}>
+
+      <div className="flex min-h-56 items-center justify-center rounded-lg border border-foreground/10 bg-secondary/35 px-5">
         <AnimatedText data={"Hello world"} />
       </div>
     </section>

--- a/app/[locale]/show/model-card-artwork/page.tsx
+++ b/app/[locale]/show/model-card-artwork/page.tsx
@@ -2,39 +2,51 @@ import type { Route } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 
-import Header from "@/components/header";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
 import { modelCardArtworks } from "./assets";
+
+export const metadata = NewMetadata({
+  description: "Artwork studies for language model cards.",
+  title: "minpeter | model card artwork",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/model-card-artwork">
 ) {
   const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
   return (
-    <section className="flex flex-col gap-3">
-      <Header
-        link={{ href: `/${locale}/show` as Route, text: t("back") }}
-        title="/show/model-card-artwork"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="Visual studies made for language model launch cards."
+        href={`/${locale}/show` as Route}
+        kicker="Artwork study"
+        title="Model card artwork"
       />
-      <div className="grid grid-cols-1 items-center gap-3 sm:grid-cols-2 md:grid-cols-3">
+
+      <div className="grid grid-cols-3 items-start gap-3">
         {modelCardArtworks.map((artwork) => (
-          <Image
-            alt={artwork.alt}
-            key={artwork.alt}
-            placeholder="blur"
-            src={artwork.src}
-          />
+          <div className="overflow-hidden bg-secondary" key={artwork.alt}>
+            <Image
+              alt={artwork.alt}
+              className="h-auto w-full"
+              placeholder="blur"
+              sizes="(min-width: 512px) 162px, calc((100vw - 64px) / 3)"
+              src={artwork.src}
+            />
+          </div>
         ))}
       </div>
 
-      <hr />
-
-      <p className="text-xs">
-        About the original image ⓒ 2024. NousResearch Corp. All rights reserved.
-      </p>
-      <p className="text-xs">
-        About the original image ⓒ 2025. イシガミ　アキラ All rights reserved.
-      </p>
+      <aside className="mt-12 border-foreground/15 border-t pt-5">
+        <p className="showcase-kicker">Image credits</p>
+        <div className="space-y-1 text-[0.6875rem] text-muted-foreground leading-relaxed">
+          <p>Original image © 2024 NousResearch Corp. All rights reserved.</p>
+          <p>Original image © 2025 イシガミ アキラ. All rights reserved.</p>
+        </div>
+      </aside>
     </section>
   );
 }

--- a/app/[locale]/show/new-year-clock/countdown.tsx
+++ b/app/[locale]/show/new-year-clock/countdown.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface TimeLeft {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const TIMER_INTERVAL_MS = MILLISECONDS_PER_SECOND;
+
+const ZERO_TIME_LEFT: TimeLeft = {
+  days: 0,
+  hours: 0,
+  minutes: 0,
+  seconds: 0,
+};
+
+const JANUARY_INDEX = 0;
+const FIRST_DAY = 1;
+const NEXT_YEAR_OFFSET = 1;
+
+function getNextYearTimestamp() {
+  const currentYear = new Date().getFullYear();
+  return new Date(
+    currentYear + NEXT_YEAR_OFFSET,
+    JANUARY_INDEX,
+    FIRST_DAY
+  ).getTime();
+}
+
+function calculateTimeLeft(targetTimestamp: number): TimeLeft {
+  const now = Date.now();
+  const difference = targetTimestamp - now;
+
+  if (difference <= 0) {
+    return ZERO_TIME_LEFT;
+  }
+
+  const millisecondsPerMinute = MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE;
+  const millisecondsPerHour = millisecondsPerMinute * MINUTES_PER_HOUR;
+  const millisecondsPerDay = millisecondsPerHour * HOURS_PER_DAY;
+
+  return {
+    days: Math.floor(difference / millisecondsPerDay),
+    hours: Math.floor((difference / millisecondsPerHour) % HOURS_PER_DAY),
+    minutes: Math.floor(
+      (difference / millisecondsPerMinute) % SECONDS_PER_MINUTE
+    ),
+    seconds: Math.floor(
+      (difference / MILLISECONDS_PER_SECOND) % SECONDS_PER_MINUTE
+    ),
+  };
+}
+
+export function Countdown() {
+  "use no memo";
+  const [targetTimestamp] = useState(getNextYearTimestamp);
+  const [remainingTime, setRemainingTime] = useState<TimeLeft>(() =>
+    calculateTimeLeft(targetTimestamp)
+  );
+
+  useEffect(() => {
+    const updateRemainingTime = () => {
+      setRemainingTime(calculateTimeLeft(targetTimestamp));
+    };
+
+    updateRemainingTime();
+    const intervalId = window.setInterval(
+      updateRemainingTime,
+      TIMER_INTERVAL_MS
+    );
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [targetTimestamp]);
+
+  const hasTimeLeft = Object.values(remainingTime).some((value) => value > 0);
+  const units = [
+    { label: "Days", value: remainingTime.days },
+    { label: "Hours", value: remainingTime.hours },
+    { label: "Minutes", value: remainingTime.minutes },
+    { label: "Seconds", value: remainingTime.seconds },
+  ] as const;
+
+  if (!hasTimeLeft) {
+    return (
+      <div className="rounded-lg border border-foreground/10 bg-secondary/35 px-5 py-12 text-center">
+        <p className="text-xl tracking-[-0.035em]">Happy New Year!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      aria-label={`${remainingTime.days} days, ${remainingTime.hours} hours, ${remainingTime.minutes} minutes, and ${remainingTime.seconds} seconds until the new year`}
+      className="grid grid-cols-2 gap-x-5 gap-y-8 sm:grid-cols-4"
+      role="timer"
+    >
+      {units.map(({ label, value }) => (
+        <div className="border-foreground/15 border-t pt-4" key={label}>
+          <span className="block font-mono text-2xl tabular-nums tracking-[-0.05em] sm:text-[1.75rem]">
+            {String(value).padStart(2, "0")}
+          </span>
+          <span className="mt-1 block text-[0.6875rem] text-muted-foreground uppercase tracking-[0.08em]">
+            {label}
+          </span>
+        </div>
+      ))}
+      <p className="col-span-full text-[0.6875rem] text-muted-foreground leading-relaxed">
+        Counting down to January 1, {new Date(targetTimestamp).getFullYear()}.
+      </p>
+    </div>
+  );
+}

--- a/app/[locale]/show/new-year-clock/page.tsx
+++ b/app/[locale]/show/new-year-clock/page.tsx
@@ -1,119 +1,32 @@
-"use client";
-
 import type { Route } from "next";
-import { useLocale, useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { getTranslations } from "next-intl/server";
 
-import Header from "@/components/header";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
-export default function Page() {
-  const locale = useLocale();
-  const t = useTranslations();
+import { Countdown } from "./countdown";
+
+export const metadata = NewMetadata({
+  description: "A live countdown to the next year.",
+  title: "minpeter | new year clock",
+});
+
+export default async function Page(
+  props: PageProps<"/[locale]/show/new-year-clock">
+) {
+  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+
   return (
-    <section className="flex flex-col gap-3">
-      <Header
-        description="Countdown to the next year"
-        link={{ href: `/${locale}/show` as Route, text: t("back") }}
-        title="/show/new-year-clock"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="A live countdown that keeps its eyes on the next January first."
+        href={`/${locale}/show` as Route}
+        kicker="Time study"
+        title="New year clock"
       />
 
       <Countdown />
     </section>
-  );
-}
-
-interface TimeLeft {
-  days: number;
-  hours: number;
-  minutes: number;
-  seconds: number;
-}
-
-const MILLISECONDS_PER_SECOND = 1000;
-const SECONDS_PER_MINUTE = 60;
-const MINUTES_PER_HOUR = 60;
-const HOURS_PER_DAY = 24;
-const TIMER_INTERVAL_MS = MILLISECONDS_PER_SECOND;
-
-const ZERO_TIME_LEFT: TimeLeft = {
-  days: 0,
-  hours: 0,
-  minutes: 0,
-  seconds: 0,
-};
-
-const JANUARY_INDEX = 0;
-const FIRST_DAY = 1;
-const NEXT_YEAR_OFFSET = 1;
-
-function getNextYearTimestamp() {
-  const currentYear = new Date().getFullYear();
-  return new Date(
-    currentYear + NEXT_YEAR_OFFSET,
-    JANUARY_INDEX,
-    FIRST_DAY
-  ).getTime();
-}
-
-function calculateTimeLeft(targetTimestamp: number): TimeLeft {
-  const now = Date.now();
-  const difference = targetTimestamp - now;
-
-  if (difference <= 0) {
-    return ZERO_TIME_LEFT;
-  }
-
-  const millisecondsPerMinute = MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE;
-  const millisecondsPerHour = millisecondsPerMinute * MINUTES_PER_HOUR;
-  const millisecondsPerDay = millisecondsPerHour * HOURS_PER_DAY;
-
-  return {
-    days: Math.floor(difference / millisecondsPerDay),
-    hours: Math.floor((difference / millisecondsPerHour) % HOURS_PER_DAY),
-    minutes: Math.floor(
-      (difference / millisecondsPerMinute) % SECONDS_PER_MINUTE
-    ),
-    seconds: Math.floor(
-      (difference / MILLISECONDS_PER_SECOND) % SECONDS_PER_MINUTE
-    ),
-  };
-}
-
-function Countdown() {
-  "use no memo";
-  const [targetTimestamp] = useState(getNextYearTimestamp);
-  const [remainingTime, setRemainingTime] = useState<TimeLeft>(() =>
-    calculateTimeLeft(targetTimestamp)
-  );
-
-  useEffect(() => {
-    const updateRemainingTime = () => {
-      setRemainingTime(calculateTimeLeft(targetTimestamp));
-    };
-
-    updateRemainingTime();
-    const intervalId = window.setInterval(() => {
-      updateRemainingTime();
-    }, TIMER_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(intervalId);
-    };
-  }, [targetTimestamp]);
-
-  const hasTimeLeft = Object.values(remainingTime).some((value) => value > 0);
-  const countdownContent = hasTimeLeft ? (
-    <>
-      {remainingTime.days}일 {remainingTime.hours}시간 {remainingTime.minutes}분{" "}
-      {remainingTime.seconds}초
-    </>
-  ) : (
-    "Happy New Year!"
-  );
-
-  return (
-    <div className="whitespace-pre-wrap rounded-xl text-sm tabular-nums">
-      {countdownContent}
-    </div>
   );
 }

--- a/app/[locale]/show/tech-stack-ball/animated-stack.tsx
+++ b/app/[locale]/show/tech-stack-ball/animated-stack.tsx
@@ -4,19 +4,19 @@
 import {
   Bodies,
   Body,
+  Composite,
   Engine,
   Events,
   Mouse,
   MouseConstraint,
   Render,
   Runner,
-  World,
 } from "matter-js";
 import { useEffect, useRef } from "react";
 
 import { cn } from "@/shared/utils/tailwind";
 
-const stackIcon = [
+const STACK_ICONS = [
   "AWS.png",
   "Arch Linux.png",
   "Oh my zsh.png",
@@ -48,18 +48,33 @@ const stackIcon = [
 ];
 
 const GRAVITY_X = 0;
-const GRAVITY_Y = 0;
-const GRAVITY_SCALE = 0;
+const GRAVITY_Y = 1;
+const GRAVITY_SCALE = 0.001;
 const CANVAS_BACKGROUND = "transparent";
 const WALL_THICKNESS = 100;
 const WALL_SAFE_ZONE = 100;
-const ICON_DIAMETER = 30;
-const ICON_TEXTURE_BASE_DIMENSION = 300;
+const WALL_FRICTION = 0.2;
+const WALL_RESTITUTION = 0.2;
+const MIN_ICON_SIZE = 24;
+const MAX_ICON_SIZE = 36;
+const ICON_WIDTH_RATIO = 0.07;
+const ICON_TEXTURE_BASE_DIMENSION = 512;
+const GITHUB_TEXTURE_WIDTH = 230;
+const GITHUB_TEXTURE_HEIGHT = 225;
 const MAX_RENDERED_ICONS = 16;
-const ICON_CENTER_PULL = 0.000004;
-const ICON_FRICTION_AIR = 0.025;
-const ICON_INITIAL_SPEED = 1.35;
-const MOUSE_CONSTRAINT_STIFFNESS = 0.05;
+const ICON_FRICTION = 0.08;
+const ICON_FRICTION_AIR = 0.015;
+const ICON_FRICTION_STATIC = 0.25;
+const ICON_RESTITUTION = 0.35;
+const MOUSE_CONSTRAINT_STIFFNESS = 0.2;
+const MOUSE_CONSTRAINT_DAMPING = 0.1;
+const MOUSE_CONSTRAINT_ANGULAR_STIFFNESS = 0.1;
+const MAX_ICON_SPEED = 18;
+const MAX_ICON_ANGULAR_SPEED = 0.35;
+const MAX_PIXEL_RATIO = 2;
+const POSITION_ITERATIONS = 8;
+const VELOCITY_ITERATIONS = 6;
+const CONSTRAINT_ITERATIONS = 4;
 const CANVAS_FILTER = "grayscale(1)";
 
 function shuffleArray<T>(array: T[]): T[] {
@@ -69,6 +84,44 @@ function shuffleArray<T>(array: T[]): T[] {
     [result[i], result[j]] = [result[j], result[i]];
   }
   return result;
+}
+
+function getIconSize(width: number) {
+  return Math.max(
+    MIN_ICON_SIZE,
+    Math.min(MAX_ICON_SIZE, width * ICON_WIDTH_RATIO)
+  );
+}
+
+function getIconTextureScale(icon: string, iconSize: number) {
+  if (icon === "GitHub.png") {
+    return {
+      x: iconSize / GITHUB_TEXTURE_WIDTH,
+      y: iconSize / GITHUB_TEXTURE_HEIGHT,
+    };
+  }
+
+  return {
+    x: iconSize / ICON_TEXTURE_BASE_DIMENSION,
+    y: iconSize / ICON_TEXTURE_BASE_DIMENSION,
+  };
+}
+
+function removeMouseListeners(canvas: HTMLCanvasElement, mouse: Mouse) {
+  const handlers = mouse as Mouse & {
+    mousedown: EventListener;
+    mousemove: EventListener;
+    mouseup: EventListener;
+    mousewheel: EventListener;
+  };
+
+  canvas.removeEventListener("mousemove", handlers.mousemove);
+  canvas.removeEventListener("mousedown", handlers.mousedown);
+  canvas.removeEventListener("mouseup", handlers.mouseup);
+  canvas.removeEventListener("wheel", handlers.mousewheel);
+  canvas.removeEventListener("touchmove", handlers.mousemove);
+  canvas.removeEventListener("touchstart", handlers.mousedown);
+  canvas.removeEventListener("touchend", handlers.mouseup);
 }
 
 export function Playground({
@@ -89,7 +142,12 @@ export function Playground({
       return;
     }
 
-    const engine = Engine.create();
+    const engine = Engine.create({
+      constraintIterations: CONSTRAINT_ITERATIONS,
+      enableSleeping: true,
+      positionIterations: POSITION_ITERATIONS,
+      velocityIterations: VELOCITY_ITERATIONS,
+    });
     engine.gravity.x = GRAVITY_X;
     engine.gravity.y = GRAVITY_Y;
     engine.gravity.scale = GRAVITY_SCALE;
@@ -100,16 +158,19 @@ export function Playground({
       options: {
         background: CANVAS_BACKGROUND,
         height: h,
+        pixelRatio: Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO),
         width: w,
         wireframes: false,
       },
     });
 
     const wallProperties = {
+      friction: WALL_FRICTION,
       isStatic: true,
       render: {
         visible: false,
       },
+      restitution: WALL_RESTITUTION,
     };
     const wallThickness = WALL_THICKNESS;
     const wallOffset = -(wallThickness / 2);
@@ -151,54 +212,51 @@ export function Playground({
       )
     );
 
-    const center = { x: w / 2, y: h / 2 };
-    const iconSize = ICON_DIAMETER;
-    const iconScale = iconSize / ICON_TEXTURE_BASE_DIMENSION;
-    const selectedIcons = shuffleArray(stackIcon).slice(0, MAX_RENDERED_ICONS);
-    const boxes = selectedIcons.map((icon, index) => {
-      const angle = (index / selectedIcons.length) * Math.PI * 2;
-      const radiusByRing = [0.16, 0.27, 0.36][index % 3] ?? 0.27;
-      const radius = Math.min(w, h) * radiusByRing;
-      const body = Bodies.circle(
-        center.x + Math.cos(angle) * radius,
-        center.y + Math.sin(angle) * radius * 0.72,
-        iconSize,
+    const selectedIcons = shuffleArray(STACK_ICONS).slice(
+      0,
+      MAX_RENDERED_ICONS
+    );
+    const iconSize = getIconSize(w);
+    const iconRadius = iconSize / 2;
+    const columnCount = Math.ceil(Math.sqrt(selectedIcons.length * (w / h)));
+    const rowCount = Math.ceil(selectedIcons.length / columnCount);
+    const horizontalSpacing = w / (columnCount + 1);
+    const verticalSpawnArea = Math.min(h * 0.5, rowCount * iconSize * 1.75);
+    const verticalSpacing = verticalSpawnArea / (rowCount + 1);
+    const icons = selectedIcons.map((icon, index) => {
+      const column = index % columnCount;
+      const row = Math.floor(index / columnCount);
+      const textureScale = getIconTextureScale(icon, iconSize);
+
+      return Bodies.circle(
+        (column + 1) * horizontalSpacing,
+        iconRadius + (row + 1) * verticalSpacing,
+        iconRadius,
         {
+          angle: ((index % 5) - 2) * 0.08,
+          friction: ICON_FRICTION,
           frictionAir: ICON_FRICTION_AIR,
+          frictionStatic: ICON_FRICTION_STATIC,
+          label: icon,
           render: {
             sprite: {
               texture: `/assets/images/stack-icon/${icon}`,
-              xScale: iconScale,
-              yScale: iconScale,
+              xScale: textureScale.x,
+              yScale: textureScale.y,
             },
           },
-          restitution: 0.9,
+          restitution: ICON_RESTITUTION,
         }
       );
-
-      Body.setVelocity(body, {
-        x: -Math.sin(angle) * ICON_INITIAL_SPEED,
-        y: Math.cos(angle) * ICON_INITIAL_SPEED,
-      });
-      Body.setAngularVelocity(body, index % 2 === 0 ? 0.025 : -0.025);
-
-      return body;
     });
 
-    const keepIconsCentered = () => {
-      for (const body of boxes) {
-        Body.applyForce(body, body.position, {
-          x: (center.x - body.position.x) * body.mass * ICON_CENTER_PULL,
-          y: (center.y - body.position.y) * body.mass * ICON_CENTER_PULL,
-        });
-      }
-    };
-
-    Events.on(engine, "beforeUpdate", keepIconsCentered);
-
     const mouse = Mouse.create(render.canvas);
+    // Matter.js parses the canvas data attribute with parseInt, which breaks
+    // pointer coordinates on fractional device pixel ratios such as 1.25.
+    mouse.pixelRatio = render.options.pixelRatio ?? 1;
     const mouseConstraint = MouseConstraint.create(engine, {
       constraint: {
+        damping: MOUSE_CONSTRAINT_DAMPING,
         render: {
           visible: false,
         },
@@ -206,17 +264,76 @@ export function Playground({
       },
       mouse,
     });
+    const draggableConstraint =
+      mouseConstraint.constraint as typeof mouseConstraint.constraint & {
+        angularStiffness: number;
+      };
+    draggableConstraint.angularStiffness = MOUSE_CONSTRAINT_ANGULAR_STIFFNESS;
+    const limitIconVelocity = () => {
+      for (const icon of icons) {
+        // Preserve direct manipulation and only cap the released body's throw.
+        if (mouseConstraint.body === icon) {
+          continue;
+        }
 
-    World.add(engine.world, [...walls, mouseConstraint, ...boxes]);
+        if (Body.getSpeed(icon) > MAX_ICON_SPEED) {
+          Body.setSpeed(icon, MAX_ICON_SPEED);
+        }
 
-    Render.run(render);
+        if (Body.getAngularSpeed(icon) > MAX_ICON_ANGULAR_SPEED) {
+          Body.setAngularSpeed(icon, MAX_ICON_ANGULAR_SPEED);
+        }
+      }
+    };
+
+    Events.on(engine, "beforeUpdate", limitIconVelocity);
+
+    Composite.add(engine.world, [...walls, mouseConstraint, ...icons]);
+
     const runner = Runner.create();
-    Runner.run(runner, engine);
+    let isCanvasVisible = true;
+    let isPageVisible = !document.hidden;
+    let isRunning = false;
+
+    const syncRunningState = () => {
+      const shouldRun = isCanvasVisible && isPageVisible;
+
+      if (shouldRun && !isRunning) {
+        Render.run(render);
+        Runner.run(runner, engine);
+        isRunning = true;
+      } else if (!shouldRun && isRunning) {
+        Render.stop(render);
+        Runner.stop(runner);
+        isRunning = false;
+      }
+    };
+
+    const intersectionObserver = new IntersectionObserver(
+      ([entry]) => {
+        isCanvasVisible = entry?.isIntersecting ?? false;
+        syncRunningState();
+      },
+      { threshold: 0.01 }
+    );
+    const handleVisibilityChange = () => {
+      isPageVisible = !document.hidden;
+      syncRunningState();
+    };
+
+    intersectionObserver.observe(canvas);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    syncRunningState();
 
     return () => {
-      Events.off(engine, "beforeUpdate", keepIconsCentered);
+      intersectionObserver.disconnect();
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       Render.stop(render);
       Runner.stop(runner);
+      Events.off(engine, "beforeUpdate", limitIconVelocity);
+      removeMouseListeners(canvas, mouse);
+      Mouse.clearSourceEvents(mouse);
+      Composite.clear(engine.world, false, true);
       Engine.clear(engine);
       render.textures = {};
     };
@@ -226,7 +343,7 @@ export function Playground({
     <canvas
       aria-label="Interactive physics simulation with technology stack icons"
       className={cn(
-        "h-auto w-full max-w-full rounded-lg border bg-card text-card-foreground shadow-xs",
+        "h-auto w-full max-w-full touch-none cursor-grab rounded-lg border bg-card text-card-foreground shadow-xs active:cursor-grabbing",
         className
       )}
       height={h}

--- a/app/[locale]/show/tech-stack-ball/page.tsx
+++ b/app/[locale]/show/tech-stack-ball/page.tsx
@@ -1,28 +1,36 @@
 import type { Route } from "next";
+import { getTranslations } from "next-intl/server";
 
-import Header from "@/components/header";
-import { cn } from "@/shared/utils/tailwind";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
 import { PlaygroundWrapper } from "./playground-wrapper";
 
-import styles from "@/shared/styles/stagger-fade-in.module.css";
+export const metadata = NewMetadata({
+  description: "A spinning inventory of the tools behind this site.",
+  title: "minpeter | tech stack ball",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/tech-stack-ball">
 ) {
-  const { locale } = await props.params;
+  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+
   return (
-    <section className="flex flex-col gap-3">
-      <Header
-        description="예전엔 이게 인덱스 페이지에 있었는데, 이제는 여기에 있어요"
-        link={{ href: `/${locale}/show` as Route, text: "showcase로 돌아가기" }}
-        title="/show/tech-stack-ball"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="A draggable, floating inventory of tools used to build this site."
+        href={`/${locale}/show` as Route}
+        kicker="Physics study"
+        title="Tech stack ball"
       />
-      <div
-        className={cn(styles.stagger_container, styles.slow, "flex flex-col")}
-      >
-        <PlaygroundWrapper h={400} w={800} />
-      </div>
+
+      <PlaygroundWrapper
+        className="rounded-none border-0 bg-transparent shadow-none"
+        h={400}
+        w={800}
+      />
     </section>
   );
 }

--- a/app/[locale]/show/tech-stack-ball/playground-wrapper.tsx
+++ b/app/[locale]/show/tech-stack-ball/playground-wrapper.tsx
@@ -1,46 +1,109 @@
 "use client";
 
+import { ReloadIcon } from "@radix-ui/react-icons";
 import dynamic from "next/dynamic";
-import type { CSSProperties } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Skeleton } from "@/components/ui/skeleton";
 
 interface PlaygroundProps {
+  readonly className?: string;
   readonly h: number;
   readonly w: number;
 }
 
-interface PlaygroundFrameStyle extends CSSProperties {
-  readonly "--playground-aspect-ratio": string;
-  readonly "--playground-width": string;
+interface PlaygroundDimensions {
+  height: number;
+  width: number;
 }
-
-const playgroundSkeletonStyle = {
-  aspectRatio: "var(--playground-aspect-ratio)",
-  height: "auto",
-  maxWidth: "100%",
-  width: "var(--playground-width)",
-} satisfies CSSProperties;
 
 const Playground = dynamic<PlaygroundProps>(
   () => import("./animated-stack").then((mod) => mod.Playground),
   {
-    loading: () => (
-      <Skeleton className="rounded-lg" style={playgroundSkeletonStyle} />
-    ),
+    loading: () => <Skeleton className="h-full w-full rounded-none" />,
     ssr: false,
   }
 );
 
-export function PlaygroundWrapper({ h, w }: PlaygroundProps) {
-  const playgroundFrameStyle: PlaygroundFrameStyle = {
-    "--playground-aspect-ratio": `${w} / ${h}`,
-    "--playground-width": `${w}px`,
-  };
+export function PlaygroundWrapper({ className, h, w }: PlaygroundProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const [dimensions, setDimensions] = useState<PlaygroundDimensions | null>(
+    null
+  );
+  const [runId, setRunId] = useState(0);
+
+  useEffect(() => {
+    const frame = frameRef.current;
+
+    if (!frame) {
+      return;
+    }
+
+    let animationFrameId = 0;
+    const updateDimensions = (width: number) => {
+      window.cancelAnimationFrame(animationFrameId);
+      animationFrameId = window.requestAnimationFrame(() => {
+        const nextDimensions = {
+          height: Math.max(1, Math.round(width * (h / w))),
+          width: Math.max(1, Math.round(width)),
+        };
+
+        setDimensions((currentDimensions) => {
+          if (
+            currentDimensions?.height === nextDimensions.height &&
+            currentDimensions.width === nextDimensions.width
+          ) {
+            return currentDimensions;
+          }
+
+          return nextDimensions;
+        });
+      });
+    };
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      updateDimensions(entry?.contentRect.width ?? frame.clientWidth);
+    });
+
+    resizeObserver.observe(frame);
+    updateDimensions(frame.clientWidth);
+
+    return () => {
+      resizeObserver.disconnect();
+      window.cancelAnimationFrame(animationFrameId);
+    };
+  }, [h, w]);
+
+  const handleReplay = useCallback(() => {
+    setRunId((currentRunId) => currentRunId + 1);
+  }, []);
 
   return (
-    <div className="contents" style={playgroundFrameStyle}>
-      <Playground h={h} w={w} />
-    </div>
+    <>
+      <div className="overflow-hidden rounded-lg border border-foreground/10 bg-secondary/20">
+        <div ref={frameRef} style={{ aspectRatio: `${w} / ${h}` }}>
+          {dimensions ? (
+            <Playground
+              className={className}
+              h={dimensions.height}
+              key={`${runId}-${dimensions.width}x${dimensions.height}`}
+              w={dimensions.width}
+            />
+          ) : (
+            <Skeleton className="h-full w-full rounded-none" />
+          )}
+        </div>
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-4 text-[0.6875rem] text-muted-foreground leading-relaxed">
+        <p>Drag an icon and let the physics take over.</p>
+        <button
+          className="inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-1 transition-colors hover:bg-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          onClick={handleReplay}
+          type="button"
+        >
+          <ReloadIcon aria-hidden="true" className="size-3" />
+          Replay
+        </button>
+      </div>
+    </>
   );
 }

--- a/app/[locale]/show/unstructured-0828/page.tsx
+++ b/app/[locale]/show/unstructured-0828/page.tsx
@@ -3,24 +3,33 @@ import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
 
-import Header from "@/components/header";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
 import SaaSComponentImage from "./saas-component.png";
 import SaaSPageImage from "./saas-page.png";
+
+export const metadata = NewMetadata({
+  description: "A perspective study in layered product interfaces.",
+  title: "minpeter | unstructured 0828",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/unstructured-0828">
 ) {
   const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
   return (
-    <section className="flex flex-col gap-8">
-      <Header
-        description="unstructured 250828"
-        link={{ href: `/${locale}/show` as Route, text: t("back") }}
-        title="/show/unstructured-0828"
+    <section className="showcase-page max-w-4xl">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        className="mx-auto w-full max-w-lg"
+        description="A perspective study built from layered product interfaces."
+        href={`/${locale}/show` as Route}
+        kicker="Perspective study"
+        title="Unstructured 0828"
       />
 
-      <div className="relative z-10 mt-4 flex min-h-[340px] w-full max-w-full items-center justify-center overflow-hidden sm:min-h-[430px] md:mt-0 md:min-h-[520px] lg:min-h-[560px] xl:min-h-[700px] 2xl:min-h-[820px]">
+      <div className="relative z-10 flex min-h-[340px] w-full max-w-full items-center justify-center overflow-hidden rounded-lg border border-foreground/10 bg-secondary/20 sm:min-h-[430px] md:min-h-[520px] lg:min-h-[560px] xl:min-h-[700px] 2xl:min-h-[820px]">
         <div className="origin-center scale-[0.55] sm:scale-[0.72] md:scale-[0.82] lg:scale-[0.7] xl:scale-100 2xl:scale-[1.25]">
           <div className="[transform:perspective(4101px)_rotateX(40deg)_rotateY(5deg)_rotateZ(55deg)]">
             <div className="relative inline-block [transform:scaleX(-1)_scaleY(-1)_rotate(90deg)]">
@@ -45,6 +54,10 @@ export default async function Page(
           </div>
         </div>
       </div>
+
+      <p className="mx-auto mt-3 w-full max-w-lg text-[0.6875rem] text-muted-foreground leading-relaxed">
+        Select the floating panel to open the referenced model page.
+      </p>
     </section>
   );
 }

--- a/app/[locale]/show/unstructured/page.tsx
+++ b/app/[locale]/show/unstructured/page.tsx
@@ -1,93 +1,195 @@
 import type { Route } from "next";
 import { getTranslations } from "next-intl/server";
 
-import Header from "@/components/header";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
+import { cn } from "@/shared/utils/tailwind";
+
+import styles from "./styles.module.css";
+
+export const metadata = NewMetadata({
+  description: "Experiments in layered motion and depth.",
+  title: "minpeter | unstructured",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/unstructured">
 ) {
   const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
   return (
-    <section className="flex flex-col gap-8">
-      <Header
-        description="unstructured"
-        link={{ href: `/${locale}/show` as Route, text: t("back") }}
-        title="/show/unstructured"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="Loose experiments with layered interfaces, motion, and depth."
+        href={`/${locale}/show` as Route}
+        kicker="Motion study"
+        title="Unstructured"
       />
 
-      <div className="h-48 w-full">
-        <div
-          className="unstructured-demo unstructured-demo--stack relative h-full w-full"
-          role="presentation"
-        >
-          <div className="unstructured-layer unstructured-layer--stack-back absolute inset-0 -rotate-1 transform rounded-sm bg-neutral-600 transition-all duration-300" />
-          <div className="unstructured-layer unstructured-layer--stack-front absolute inset-0 rotate-1 transform rounded-sm bg-neutral-500 p-8 transition-all duration-300">
-            <h2 className="font-extrabold text-2xl text-neutral-200">
-              Hover me
-            </h2>
-          </div>
-        </div>
-      </div>
-
-      {/* Enhanced 3D layered animated card with twisting effect */}
-      <div className="h-48 w-full [perspective:1500px]">
-        <div
-          className="unstructured-demo unstructured-demo--depth relative h-full w-full"
-          role="presentation"
-        >
-          <div className="unstructured-layer unstructured-layer--depth-one absolute inset-0 flex transform items-center justify-center rounded-sm bg-neutral-600 transition-all duration-500 ease-out">
-            <span className="font-extrabold text-2xl text-white drop-shadow-md">
-              Layer 1
-            </span>
-          </div>
-          <div className="unstructured-layer unstructured-layer--depth-two absolute inset-0 flex transform items-center justify-center rounded-sm bg-neutral-500 transition-all duration-500 ease-out">
-            <span className="font-extrabold text-2xl text-white drop-shadow-md">
-              Layer 2
-            </span>
-          </div>
-          <div className="unstructured-layer unstructured-layer--depth-three absolute inset-0 flex transform items-center justify-center rounded-sm bg-neutral-400 transition-all duration-500 ease-out">
-            <span className="font-extrabold text-2xl text-white drop-shadow-md">
-              Layer 3
-            </span>
-          </div>
-        </div>
-      </div>
-
-      {/* Side-view transition with layer separation effect */}
-      <div className="h-48 w-full [perspective:1500px]">
-        <div
-          className="unstructured-demo unstructured-demo--side relative h-full w-full"
-          role="presentation"
-        >
-          <div className="unstructured-layer unstructured-layer--side-front absolute inset-0 origin-left transform rounded-sm bg-neutral-700 shadow-lg transition-all duration-700 ease-out">
-            <div className="flex h-full p-6">
-              <span className="font-extrabold text-2xl text-white drop-shadow-md">
-                Front
-              </span>
+      <div className="space-y-10">
+        <figure>
+          <figcaption className="mb-3 flex items-center justify-between text-[0.6875rem] text-muted-foreground uppercase tracking-[0.08em]">
+            <span>Counter rotation</span>
+            <span className="font-mono">01</span>
+          </figcaption>
+          <div className="h-48 w-full">
+            <div
+              aria-label="Two layered cards rotating in opposite directions on hover"
+              className={cn(
+                styles.demo,
+                styles.stack,
+                "relative h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              )}
+              role="img"
+              tabIndex={0}
+            >
+              <div
+                className={cn(
+                  styles.stackBack,
+                  "absolute inset-0 -rotate-1 transform rounded-md bg-neutral-600 transition-all duration-300"
+                )}
+              />
+              <div
+                className={cn(
+                  styles.stackFront,
+                  "absolute inset-0 rotate-1 transform rounded-md bg-neutral-500 p-8 transition-all duration-300"
+                )}
+              >
+                <h2 className="font-medium text-2xl text-neutral-100 tracking-[-0.04em]">
+                  Hover me
+                </h2>
+              </div>
             </div>
           </div>
+        </figure>
 
-          <div className="unstructured-layer unstructured-layer--side-middle absolute inset-0 origin-left transform rounded-md bg-neutral-600 shadow-lg transition-all duration-700 ease-out">
-            <div className="flex h-full p-6">
-              <span className="unstructured-copy unstructured-copy--side-middle font-extrabold text-white text-xl opacity-0 drop-shadow-md transition-opacity delay-100 duration-300">
-                Middle
-              </span>
+        <figure>
+          <figcaption className="mb-3 flex items-center justify-between text-[0.6875rem] text-muted-foreground uppercase tracking-[0.08em]">
+            <span>Depth separation</span>
+            <span className="font-mono">02</span>
+          </figcaption>
+          <div className="h-48 w-full [perspective:1500px]">
+            <div
+              aria-label="Three cards separating in three-dimensional space on hover"
+              className={cn(
+                styles.demo,
+                styles.depth,
+                "relative h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              )}
+              role="img"
+              tabIndex={0}
+            >
+              <div
+                className={cn(
+                  styles.depthOne,
+                  "absolute inset-0 flex transform items-center justify-center rounded-md bg-neutral-600 transition-all duration-500 ease-out"
+                )}
+              >
+                <span className="font-medium text-2xl text-white tracking-[-0.04em] drop-shadow-md">
+                  Layer 1
+                </span>
+              </div>
+              <div
+                className={cn(
+                  styles.depthTwo,
+                  "absolute inset-0 flex transform items-center justify-center rounded-md bg-neutral-500 transition-all duration-500 ease-out"
+                )}
+              >
+                <span className="font-medium text-2xl text-white tracking-[-0.04em] drop-shadow-md">
+                  Layer 2
+                </span>
+              </div>
+              <div
+                className={cn(
+                  styles.depthThree,
+                  "absolute inset-0 flex transform items-center justify-center rounded-md bg-neutral-400 transition-all duration-500 ease-out"
+                )}
+              >
+                <span className="font-medium text-2xl text-white tracking-[-0.04em] drop-shadow-md">
+                  Layer 3
+                </span>
+              </div>
             </div>
           </div>
+        </figure>
 
-          <div className="unstructured-layer unstructured-layer--side-back absolute inset-x-4 inset-y-6 flex origin-left transform flex-row gap-6 rounded-sm p-3 transition-all duration-700 ease-out">
-            <div className="flex h-full w-1/2 rounded-lg bg-neutral-500 p-6">
-              <span className="unstructured-copy unstructured-copy--side-back-one font-extrabold text-lg text-white opacity-0 drop-shadow-md transition-opacity delay-200 duration-300">
-                Back 1
-              </span>
-            </div>
-            <div className="flex h-full w-1/2 rounded-lg bg-neutral-400 p-6">
-              <span className="unstructured-copy unstructured-copy--side-back-two font-extrabold text-lg text-white opacity-0 drop-shadow-md transition-opacity delay-300 duration-300">
-                Back 2
-              </span>
+        <figure>
+          <figcaption className="mb-3 flex items-center justify-between text-[0.6875rem] text-muted-foreground uppercase tracking-[0.08em]">
+            <span>Side view</span>
+            <span className="font-mono">03</span>
+          </figcaption>
+          <div className="h-48 w-full [perspective:1500px]">
+            <div
+              aria-label="A card opening into three side-view layers on hover"
+              className={cn(
+                styles.demo,
+                styles.side,
+                "relative h-full w-full rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              )}
+              role="img"
+              tabIndex={0}
+            >
+              <div
+                className={cn(
+                  styles.sideFront,
+                  "absolute inset-0 z-30 origin-left transform rounded-md bg-neutral-700 shadow-lg transition-all duration-700 ease-out"
+                )}
+              >
+                <div className="flex h-full p-6">
+                  <span className="font-medium text-2xl text-white tracking-[-0.04em] drop-shadow-md">
+                    Front
+                  </span>
+                </div>
+              </div>
+
+              <div
+                className={cn(
+                  styles.sideMiddle,
+                  "absolute inset-0 z-20 origin-left transform rounded-md bg-neutral-600 shadow-lg transition-all duration-700 ease-out"
+                )}
+              >
+                <div className="flex h-full p-6">
+                  <span
+                    className={cn(
+                      styles.copy,
+                      "font-medium text-white text-xl opacity-0 tracking-[-0.04em] drop-shadow-md transition-opacity delay-100 duration-300"
+                    )}
+                  >
+                    Middle
+                  </span>
+                </div>
+              </div>
+
+              <div
+                className={cn(
+                  styles.sideBack,
+                  "absolute inset-x-4 inset-y-6 z-10 flex origin-left transform flex-row gap-6 rounded-md p-3 transition-all duration-700 ease-out"
+                )}
+              >
+                <div className="flex h-full w-1/2 rounded-md bg-neutral-500 p-6">
+                  <span
+                    className={cn(
+                      styles.copy,
+                      "font-medium text-lg text-white opacity-0 tracking-[-0.04em] drop-shadow-md transition-opacity delay-200 duration-300"
+                    )}
+                  >
+                    Back 1
+                  </span>
+                </div>
+                <div className="flex h-full w-1/2 rounded-md bg-neutral-400 p-6">
+                  <span
+                    className={cn(
+                      styles.copy,
+                      "font-medium text-lg text-white opacity-0 tracking-[-0.04em] drop-shadow-md transition-opacity delay-300 duration-300"
+                    )}
+                  >
+                    Back 2
+                  </span>
+                </div>
+              </div>
             </div>
           </div>
-        </div>
+        </figure>
       </div>
     </section>
   );

--- a/app/[locale]/show/unstructured/styles.module.css
+++ b/app/[locale]/show/unstructured/styles.module.css
@@ -1,0 +1,87 @@
+.demo {
+  transform-style: preserve-3d;
+}
+
+@media (any-hover: hover) and (any-pointer: fine) {
+  .stack:hover .stackBack {
+    transform: rotate(1deg);
+  }
+
+  .stack:hover .stackFront {
+    transform: rotate(-1deg);
+  }
+
+  .depth:hover .depthOne {
+    transform: translate3d(-15px, -15px, 40px) rotateX(10deg) rotateY(-5deg);
+  }
+
+  .depth:hover .depthTwo {
+    transform: translate3d(0, 0, 20px) rotateX(5deg) rotateY(-3deg);
+  }
+
+  .depth:hover .depthThree {
+    transform: translate3d(15px, 15px, -10px) rotateX(-5deg) rotateY(-8deg);
+  }
+
+  .side:hover .sideFront {
+    transform: translate3d(-20px, -10px, 0) rotateY(30deg);
+  }
+
+  .side:hover .sideMiddle {
+    inset: 0.5rem;
+    transform: translate3d(0, 10px, 100px) rotateY(30deg);
+  }
+
+  .side:hover .sideBack {
+    transform: translate3d(20px, 30px, 200px) rotateY(30deg);
+  }
+
+  .side:hover .copy {
+    opacity: 1;
+  }
+}
+
+.stack:focus-visible .stackBack {
+  transform: rotate(1deg);
+}
+
+.stack:focus-visible .stackFront {
+  transform: rotate(-1deg);
+}
+
+.depth:focus-visible .depthOne {
+  transform: translate3d(-15px, -15px, 40px) rotateX(10deg) rotateY(-5deg);
+}
+
+.depth:focus-visible .depthTwo {
+  transform: translate3d(0, 0, 20px) rotateX(5deg) rotateY(-3deg);
+}
+
+.depth:focus-visible .depthThree {
+  transform: translate3d(15px, 15px, -10px) rotateX(-5deg) rotateY(-8deg);
+}
+
+.side:focus-visible .sideFront {
+  transform: translate3d(-20px, -10px, 0) rotateY(30deg);
+}
+
+.side:focus-visible .sideMiddle {
+  inset: 0.5rem;
+  transform: translate3d(0, 10px, 100px) rotateY(30deg);
+}
+
+.side:focus-visible .sideBack {
+  transform: translate3d(20px, 30px, 200px) rotateY(30deg);
+}
+
+.side:focus-visible .copy {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo *,
+  .demo *::before,
+  .demo *::after {
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/app/[locale]/show/yet-another-tempfiles/page.tsx
+++ b/app/[locale]/show/yet-another-tempfiles/page.tsx
@@ -1,28 +1,37 @@
 import type { Route } from "next";
+import { getTranslations } from "next-intl/server";
 
-import Header from "@/components/header";
-import { cn } from "@/shared/utils/tailwind";
+import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import NewMetadata from "@/shared/utils/metadata";
 
 import TmpfUI from "./tmpf";
 
-import styles from "@/shared/styles/stagger-fade-in.module.css";
+export const metadata = NewMetadata({
+  description: "A simpler frontend for temporary files.",
+  title: "minpeter | yet another tempfiles",
+});
 
 export default async function Page(
   props: PageProps<"/[locale]/show/yet-another-tempfiles">
 ) {
-  const { locale } = await props.params;
+  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+
   return (
-    <section className="flex flex-col gap-3">
-      <Header
-        description="tmpf.me보다 간단한 대체 프론트엔드"
-        link={{ href: `/${locale}/show` as Route, text: "showcase로 돌아가기" }}
-        title="/show/yet-another-tempfiles"
+    <section className="showcase-page">
+      <ShowcaseDetailHeader
+        backLabel={t("back")}
+        description="A small, direct interface for uploading temporary files."
+        href={`/${locale}/show` as Route}
+        kicker="Utility study"
+        title="Yet another tempfiles"
       />
-      <div
-        className={cn(styles.stagger_container, styles.slow, "flex flex-col")}
-      >
+
+      <div className="rounded-lg border border-foreground/10 bg-secondary/25 p-5 sm:p-6">
         <TmpfUI />
       </div>
+      <p className="mt-3 text-[0.6875rem] text-muted-foreground leading-relaxed">
+        Files are uploaded to tmpf.me and may be publicly accessible by URL.
+      </p>
     </section>
   );
 }

--- a/app/[locale]/show/yet-another-tempfiles/tmpf.tsx
+++ b/app/[locale]/show/yet-another-tempfiles/tmpf.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { DownloadIcon, EyeOpenIcon } from "@radix-ui/react-icons";
+import {
+  DownloadIcon,
+  ExclamationTriangleIcon,
+  EyeOpenIcon,
+  ReloadIcon,
+} from "@radix-ui/react-icons";
 import axios from "axios";
 import { useState } from "react";
 
@@ -96,7 +101,7 @@ export default function TmpfUI() {
     const response = await uploadFile(files);
     setUploaded(response);
     if (!response) {
-      setError("Upload failed. Please try again.");
+      setError("Check your connection and try again in a moment.");
     }
     setLoading(false);
   };
@@ -138,8 +143,28 @@ export default function TmpfUI() {
         </div>
       </div>
 
-      {error ? <p className="text-red-400 text-sm">{error}</p> : null}
-      {loading ? <p>Uploading...</p> : null}
+      {error ? (
+        <div
+          className="flex w-full max-w-md items-center gap-1.5 text-[0.6875rem] text-muted-foreground leading-relaxed"
+          role="alert"
+        >
+          <ExclamationTriangleIcon
+            aria-hidden="true"
+            className="size-3 shrink-0 text-destructive/75"
+          />
+          <span>Upload failed — {error}</span>
+        </div>
+      ) : null}
+      {loading ? (
+        <div
+          aria-live="polite"
+          className="flex w-full items-center gap-2 text-[0.75rem] text-muted-foreground"
+          role="status"
+        >
+          <ReloadIcon aria-hidden="true" className="size-3.5 animate-spin" />
+          Uploading files…
+        </div>
+      ) : null}
       {hasUploadedFiles ? (
         <>
           <div className="flex max-w-full flex-wrap items-center gap-x-4 gap-y-2">

--- a/app/globals.css
+++ b/app/globals.css
@@ -842,47 +842,6 @@
   .blog-post-page > section:last-child a:hover {
     color: hsl(var(--foreground));
   }
-
-  /* The unstructured demos only respond to real pointer hover. This prevents
-     touch browsers from applying a sticky 3D transform after a tap. */
-  @media (hover: hover) and (pointer: fine) {
-    .unstructured-demo--stack:hover .unstructured-layer--stack-back {
-      transform: rotate(1deg);
-    }
-
-    .unstructured-demo--stack:hover .unstructured-layer--stack-front {
-      transform: rotate(-1deg);
-    }
-
-    .unstructured-demo--depth:hover .unstructured-layer--depth-one {
-      transform: translate3d(-15px, -15px, 40px) rotateX(10deg) rotateY(-5deg);
-    }
-
-    .unstructured-demo--depth:hover .unstructured-layer--depth-two {
-      transform: translate3d(0, 0, 20px) rotateX(5deg) rotateY(-3deg);
-    }
-
-    .unstructured-demo--depth:hover .unstructured-layer--depth-three {
-      transform: translate3d(15px, 15px, -10px) rotateX(-5deg) rotateY(-8deg);
-    }
-
-    .unstructured-demo--side:hover .unstructured-layer--side-front {
-      transform: translate3d(-20px, -10px, 0) rotateY(30deg);
-    }
-
-    .unstructured-demo--side:hover .unstructured-layer--side-middle {
-      inset: 0.5rem;
-      transform: translate3d(0, 10px, 0) rotateY(30deg) translateZ(100px);
-    }
-
-    .unstructured-demo--side:hover .unstructured-layer--side-back {
-      transform: translate3d(20px, 30px, 0) rotateY(30deg) translateZ(200px);
-    }
-
-    .unstructured-demo--side:hover .unstructured-copy {
-      opacity: 1;
-    }
-  }
 }
 
 /* ============================================

--- a/components/showcase-detail-header.tsx
+++ b/components/showcase-detail-header.tsx
@@ -1,0 +1,53 @@
+import type { Route } from "next";
+import Image from "next/image";
+import Link from "next/link";
+
+import { cn } from "@/shared/utils/tailwind";
+
+import { LanguageSelector } from "./language-selector";
+
+interface ShowcaseDetailHeaderProps {
+  backLabel: string;
+  className?: string;
+  description: string;
+  href: Route;
+  kicker: string;
+  title: string;
+}
+
+export function ShowcaseDetailHeader({
+  backLabel,
+  className,
+  description,
+  href,
+  kicker,
+  title,
+}: ShowcaseDetailHeaderProps) {
+  return (
+    <header className={cn("showcase-header", className)}>
+      <nav aria-label={`${title} navigation`} className="fieldnotes-nav">
+        <Link
+          aria-label={`${backLabel} — Showcase`}
+          className="fieldnotes-logo-link"
+          href={href}
+        >
+          <Image
+            alt=""
+            aria-hidden="true"
+            className="fieldnotes-logo"
+            height={32}
+            priority
+            src="/assets/signature-mark.svg"
+            width={32}
+          />
+        </Link>
+        <LanguageSelector />
+      </nav>
+      <div className="showcase-intro">
+        <p className="showcase-kicker">{kicker}</p>
+        <h1 className="showcase-title">{title}</h1>
+        <p className="showcase-description">{description}</p>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary

- align every showcase detail page with the redesigned site using a shared detail header, consistent spacing, metadata, and responsive layouts
- refresh the artwork, countdown, hacked text, unstructured, and temporary-file demos while keeping their original interactions intact
- move unstructured animation rules out of global CSS into a route-scoped CSS module
- rebuild the tech stack physics demo with downward gravity, responsive/DPR-aware rendering, replay controls, safer collision handling, pointer-coordinate fixes, and off-screen pausing
- polish temporary upload loading and failure feedback

## Why

The showcase index had moved to the new visual system, but most detail pages still used the legacy header and layout. Several demos also had interaction regressions: unstructured hover rules were globally scoped and gated too narrowly, while the physics demo disabled gravity, pulled icons toward the center, and could misread pointer coordinates on fractional device pixel ratios.

## Impact

Showcase pages now feel consistent with the rest of the site across desktop and mobile. Interactive demos retain their character while behaving more predictably, and route-specific styling no longer leaks through the global stylesheet.

## Validation

- `pnpm check`
- `pnpm test` — 14 test files, 29 tests passed
- local smoke checks returned HTTP 200 for all showcase detail routes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes all showcase experiment pages to match the redesigned site and improve demo interactions and accessibility. Adds a shared detail header, consistent layouts, and rebuilt experiences where needed.

- **New Features**
  - Shared `ShowcaseDetailHeader` and unified "showcase-page" layout across detail routes; localized back link and per-page `NewMetadata`.
  - Rebuilt tech stack physics demo: downward gravity, DPR-aware rendering, velocity/rotation caps, off-screen pausing, replay button, and smoother dragging.
  - Extracted `Countdown` for the New Year clock with accessible timer labels and a zero-state (“Happy New Year!”).
  - Tempfiles UI shows a spinner and clear error alerts for failed uploads.

- **Refactors**
  - Moved unstructured animations from global CSS to a route-scoped module; added focus-visible and reduced-motion support to prevent style leaks.
  - Updated artwork page with a responsive 3‑column grid, `sizes` hints, and image credits; standardized rounded, bordered containers across pages.
  - Physics demo internals: safer engine/mouse cleanup and DPR-correct pointer coordinates on fractional pixel ratios.

<sup>Written for commit 683af977ce6ac286a38765dee3a83f9a91a98eb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

