### PR TITLE
refactor(i18n): route internal links through next-intl navigation

### DIFF
--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { render } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
 import type * as intlServer from "next-intl/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -20,7 +21,12 @@ describe("app/[locale]/73e3da.../page.tsx poem", () => {
       searchParams: Promise.resolve({}),
     });
 
-    const { container } = render(ui);
+    // The backlink resolves its locale prefix through next-intl navigation.
+    const { container } = render(
+      <NextIntlClientProvider locale="ko" messages={{}}>
+        {ui}
+      </NextIntlClientProvider>
+    );
     const section = container.querySelector("section");
 
     expect(section?.className).toContain("gap-6");

--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
@@ -8,6 +8,7 @@ import Page from "../page";
 
 vi.mock(import("next-intl/server"), () => ({
   getTranslations: vi.fn(() => (key: string) => key),
+  setRequestLocale: vi.fn<() => void>(),
 }) as unknown as Partial<typeof intlServer>);
 
 vi.mock(import("@/shared/styles/stagger-fade-in.module.css"), () => ({

--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
 import { Backlink } from "@/components/link";
 import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
@@ -22,8 +22,12 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  _props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
+  props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
 ) {
+  const { locale } = await props.params;
+  // Opts the page into static rendering: a page that never reads `params`
+  // drops out of the per-locale prerender manifest.
+  setRequestLocale(resolveLocale(locale));
   const t = await getTranslations();
   return (
     <section className="flex flex-col gap-6">

--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { Backlink } from "@/components/link";
@@ -22,14 +22,13 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
+  _props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
 ) {
-  const { locale } = await props.params;
   const t = await getTranslations();
   return (
     <section className="flex flex-col gap-6">
       <div className={cn(styles.stagger_container, styles.fast)}>
-        <Backlink href={`/${locale}` as Route} text={t("back")} />
+        <Backlink href="/" text={t("back")} />
       </div>
       <div
         className={cn(styles.stagger_container, styles.slow, "flex flex-col")}

--- a/app/[locale]/__tests__/error.test.tsx
+++ b/app/[locale]/__tests__/error.test.tsx
@@ -52,7 +52,9 @@ describe("app/[locale]/error.tsx", () => {
     expect(reset).toHaveBeenCalledOnce();
 
     const homeLink = screen.getByRole("link", { name: "홈으로 돌아가기" });
-    expect(homeLink.getAttribute("href")).toBe("/ko");
+    // `localePrefix: "as-needed"` — the default locale is served unprefixed,
+    // so linking to `/ko` would only trigger a redirect to `/`.
+    expect(homeLink.getAttribute("href")).toBe("/");
   });
 
   it("does not render a digest section when no digest is available", () => {

--- a/app/[locale]/blog/[...slug]/__tests__/error.test.tsx
+++ b/app/[locale]/blog/[...slug]/__tests__/error.test.tsx
@@ -44,6 +44,6 @@ describe("app/[locale]/blog/[...slug]/error.tsx", () => {
     expect(reset).toHaveBeenCalledOnce();
 
     const blogLink = screen.getByRole("link", { name: "글 목록으로 돌아가기" });
-    expect(blogLink.getAttribute("href")).toBe("/ko/blog");
+    expect(blogLink.getAttribute("href")).toBe("/blog");
   });
 });

--- a/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
+++ b/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
@@ -76,7 +76,7 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
     );
 
     const backLink = screen.getByRole("link", { name: "글 목록으로" });
-    expect(backLink.getAttribute("href")).toBe("/ko/blog");
+    expect(backLink.getAttribute("href")).toBe("/blog");
   });
 
   it("keeps the redirect panel inside one viewport under the header", async () => {

--- a/app/[locale]/blog/[...slug]/not-found.tsx
+++ b/app/[locale]/blog/[...slug]/not-found.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { NotFoundPage } from "@/components/not-found-page";
@@ -22,7 +22,7 @@ export default async function NotFound() {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
   return (
     <NotFoundPage
-      backHref={`/${locale}/blog` as Route}
+      backHref={getLocalizedPath(locale, "/blog")}
       backLabel={t("backToBlog")}
       description={t("notFound.description")}
       navigationLabel={t("notFound.navigationLabel")}

--- a/app/[locale]/blog/[...slug]/page.tsx
+++ b/app/[locale]/blog/[...slug]/page.tsx
@@ -1,5 +1,4 @@
 import { DocsBody } from "fumadocs-ui/page";
-import type { Route } from "next";
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
 
@@ -97,7 +96,7 @@ export default async function Page(
         )}
       >
         <Header
-          link={{ href: `/${locale}/blog` as Route, text: t("backToBlog") }}
+          link={{ href: "/blog", text: t("backToBlog") }}
           title={post.data.title}
         />
         <ExternalRedirect url={post.data.external_url} />
@@ -114,7 +113,7 @@ export default async function Page(
     >
       <Header
         description={formatDateLong(post.data.published)}
-        link={{ href: `/${locale}/blog` as Route, text: t("backToBlog") }}
+        link={{ href: "/blog", text: t("backToBlog") }}
         title={post.data.title}
         titleTransitionName={`blog-title-${post.url.replaceAll("/", "-")}`}
       />

--- a/app/[locale]/blog/__tests__/error.test.tsx
+++ b/app/[locale]/blog/__tests__/error.test.tsx
@@ -44,6 +44,6 @@ describe("app/[locale]/blog/error.tsx", () => {
     expect(reset).toHaveBeenCalledOnce();
 
     const homeLink = screen.getByRole("link", { name: "홈으로 돌아가기" });
-    expect(homeLink.getAttribute("href")).toBe("/ko");
+    expect(homeLink.getAttribute("href")).toBe("/");
   });
 });

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,10 +1,10 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
 import { Suspense } from "react";
 
 import { LanguageSelector } from "@/components/language-selector";
+import { Link } from "@/shared/i18n/navigation";
 import { blog, getPostsMetadata } from "@/shared/source";
 import {
   createMetadata,
@@ -54,7 +54,7 @@ export default async function Page(props: PageProps<"/[locale]/blog">) {
           <Link
             aria-label={t("backToHome")}
             className="fieldnotes-logo-link"
-            href={`/${locale}` as Route}
+            href="/"
           >
             <Image
               alt=""

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { NotFoundPage } from "@/components/not-found-page";
@@ -22,7 +22,7 @@ export default async function NotFound() {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
   return (
     <NotFoundPage
-      backHref={`/${locale}` as Route}
+      backHref={getLocalizedPath(locale, "/")}
       backLabel={t("backToHome")}
       description={t("notFound.description")}
       navigationLabel={t("notFound.navigationLabel")}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
-import type { Route } from "next";
-import { useLocale, useTranslations } from "next-intl";
+import { useTranslations } from "next-intl";
 import Image from "next/image";
-import Link from "next/link";
+
+import { Link } from "@/shared/i18n/navigation";
 
 const SECTIONS = [
   {
@@ -32,7 +32,6 @@ const SOCIAL_LINKS = [
 ] as const;
 
 export default function Page() {
-  const locale = useLocale();
   const t = useTranslations("home");
 
   return (
@@ -41,7 +40,7 @@ export default function Page() {
         <Link
           aria-label={t("homeLabel")}
           className="home-logo-link mb-6 inline-flex -m-2.5 p-2.5 hover:opacity-60"
-          href={`/${locale}` as Route}
+          href="/"
         >
           <Image
             alt=""
@@ -64,11 +63,7 @@ export default function Page() {
 
       <nav aria-label={t("exploreLabel")} className="home-links">
         {SECTIONS.map(({ descriptionKey, href, titleKey }) => (
-          <Link
-            className="home-link group"
-            href={`/${locale}${href}` as Route}
-            key={href}
-          >
+          <Link className="home-link group" href={href} key={href}>
             <span className="home-link-title">{t(titleKey)}</span>
             <span className="home-link-description">{t(descriptionKey)}</span>
           </Link>

--- a/app/[locale]/resume/page.tsx
+++ b/app/[locale]/resume/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import Image from "next/image";
 
 import { LanguageSelector } from "@/components/language-selector";
@@ -21,7 +21,11 @@ export async function generateMetadata(
   });
 }
 
-export default async function Page(_props: PageProps<"/[locale]/resume">) {
+export default async function Page(props: PageProps<"/[locale]/resume">) {
+  const { locale } = await props.params;
+  // Opts the page into static rendering: a page that never reads `params`
+  // drops out of the per-locale prerender manifest (and thus the sitemap).
+  setRequestLocale(resolveLocale(locale));
   const t = await getTranslations();
 
   return (

--- a/app/[locale]/resume/page.tsx
+++ b/app/[locale]/resume/page.tsx
@@ -1,9 +1,9 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
 
 import { LanguageSelector } from "@/components/language-selector";
+import { Link } from "@/shared/i18n/navigation";
 import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
 
 export async function generateMetadata(
@@ -21,8 +21,7 @@ export async function generateMetadata(
   });
 }
 
-export default async function Page(props: PageProps<"/[locale]/resume">) {
-  const { locale } = await props.params;
+export default async function Page(_props: PageProps<"/[locale]/resume">) {
   const t = await getTranslations();
 
   return (
@@ -35,7 +34,7 @@ export default async function Page(props: PageProps<"/[locale]/resume">) {
           <Link
             aria-label={t("backToHome")}
             className="fieldnotes-logo-link"
-            href={`/${locale}` as Route}
+            href="/"
           >
             <Image
               alt=""
@@ -63,7 +62,7 @@ export default async function Page(props: PageProps<"/[locale]/resume">) {
         <p className="resume-message-description">
           {t("resume.statusDescription")}
         </p>
-        <Link className="resume-home-link" href={`/${locale}` as Route}>
+        <Link className="resume-home-link" href="/">
           {t("resume.homeLabel")} <span aria-hidden="true">↗</span>
         </Link>
       </section>

--- a/app/[locale]/show/dynamic-hacked-text/page.tsx
+++ b/app/[locale]/show/dynamic-hacked-text/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
@@ -22,16 +22,16 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/dynamic-hacked-text">
+  _props: PageProps<"/[locale]/show/dynamic-hacked-text">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
 
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.dynamicText.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.dynamicText.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.dynamicText.title"),

--- a/app/[locale]/show/model-card-artwork/page.tsx
+++ b/app/[locale]/show/model-card-artwork/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 
@@ -23,15 +23,15 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/model-card-artwork">
+  _props: PageProps<"/[locale]/show/model-card-artwork">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.modelCard.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.modelCard.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.modelCard.title"),

--- a/app/[locale]/show/new-year-clock/page.tsx
+++ b/app/[locale]/show/new-year-clock/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
@@ -22,16 +22,16 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/new-year-clock">
+  _props: PageProps<"/[locale]/show/new-year-clock">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
 
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.newYear.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.newYear.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.newYear.title"),

--- a/app/[locale]/show/page.tsx
+++ b/app/[locale]/show/page.tsx
@@ -1,9 +1,9 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
-import Link from "next/link";
 
 import { LanguageSelector } from "@/components/language-selector";
+import { Link } from "@/shared/i18n/navigation";
 import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
 
 export async function generateMetadata(
@@ -48,8 +48,8 @@ const SHOWCASE_ITEMS = [
   },
 ] as const;
 
-export default async function Page(props: PageProps<"/[locale]/show">) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+export default async function Page(_props: PageProps<"/[locale]/show">) {
+  const t = await getTranslations();
   return (
     <section className="showcase-page">
       <header className="showcase-header">
@@ -60,7 +60,7 @@ export default async function Page(props: PageProps<"/[locale]/show">) {
           <Link
             aria-label={t("backToHome")}
             className="fieldnotes-logo-link"
-            href={`/${locale}` as Route}
+            href="/"
           >
             <Image
               alt=""
@@ -85,7 +85,7 @@ export default async function Page(props: PageProps<"/[locale]/show">) {
         {SHOWCASE_ITEMS.map(({ key, path }) => (
           <Link
             className="showcase-item-link"
-            href={`/${locale}${path}` as Route}
+            href={path}
             key={path}
           >
             <span className="showcase-item-top">

--- a/app/[locale]/show/tech-stack-ball/page.tsx
+++ b/app/[locale]/show/tech-stack-ball/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
@@ -22,16 +22,16 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/tech-stack-ball">
+  _props: PageProps<"/[locale]/show/tech-stack-ball">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
 
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.techStack.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.techStack.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.techStack.title"),

--- a/app/[locale]/show/unstructured-0828/page.tsx
+++ b/app/[locale]/show/unstructured-0828/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
 import Link from "next/link";
@@ -25,16 +25,16 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/unstructured-0828">
+  _props: PageProps<"/[locale]/show/unstructured-0828">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
   return (
     <section className="showcase-page max-w-4xl">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         className="mx-auto w-full max-w-lg"
         description={t("showcase.items.unstructured0828.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.unstructured0828.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.unstructured0828.title"),

--- a/app/[locale]/show/unstructured/page.tsx
+++ b/app/[locale]/show/unstructured/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
@@ -23,15 +23,15 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/unstructured">
+  _props: PageProps<"/[locale]/show/unstructured">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.unstructured.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.unstructured.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.unstructured.title"),

--- a/app/[locale]/show/yet-another-tempfiles/page.tsx
+++ b/app/[locale]/show/yet-another-tempfiles/page.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
@@ -22,16 +22,16 @@ export async function generateMetadata(
 }
 
 export default async function Page(
-  props: PageProps<"/[locale]/show/yet-another-tempfiles">
+  _props: PageProps<"/[locale]/show/yet-another-tempfiles">
 ) {
-  const [{ locale }, t] = await Promise.all([props.params, getTranslations()]);
+  const t = await getTranslations();
 
   return (
     <section className="showcase-page">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.tempfiles.description")}
-        href={`/${locale}/show` as Route}
+        href="/show"
         kicker={t("showcase.items.tempfiles.kicker")}
         navigationLabel={t("showcase.detailNavigationLabel", {
           title: t("showcase.items.tempfiles.title"),

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Route } from "next";
+import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
 
 import { NotFoundPage } from "@/components/not-found-page";
@@ -31,7 +31,7 @@ export default async function GlobalNotFound() {
   return (
     <RootDocument lang={locale}>
       <NotFoundPage
-        backHref={getLocalizedPath(locale, "/") as Route}
+        backHref={getLocalizedPath(locale, "/")}
         backLabel={t("backToHome")}
         description={t("notFound.description")}
         navigationLabel={t("notFound.navigationLabel")}

--- a/components/error-panel.tsx
+++ b/components/error-panel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { Route } from "next";
-import { useLocale, useTranslations } from "next-intl";
-import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useEffect } from "react";
+
+import { Link } from "@/shared/i18n/navigation";
 
 interface ErrorPanelProps {
   error: Error & { digest?: string };
@@ -12,12 +12,8 @@ interface ErrorPanelProps {
 }
 
 export function ErrorPanel({ error, namespace, reset }: ErrorPanelProps) {
-  const locale = useLocale();
   const t = useTranslations(`errors.${namespace}`);
-  const backHref =
-    namespace === "blog"
-      ? (`/${locale}/blog` as Route)
-      : (`/${locale}` as Route);
+  const backHref = namespace === "blog" ? "/blog" : "/";
   useEffect(() => {
     console.error(error);
   }, [error]);

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { routing } from "@/shared/i18n/routing";
-import { useLocale } from "next-intl";
-import type { Route } from "next";
-import Link from "next/link";
 import type { ReactNode } from "react";
 
 import { ViewTransition } from "@/components/view-transition";
+import { Link } from "@/shared/i18n/navigation";
 import { cn } from "@/shared/utils/tailwind";
 
 import { LanguageSelector } from "./language-selector";
@@ -17,7 +14,8 @@ import styles from "@/shared/styles/stagger-fade-in.module.css";
 interface HeaderProps {
   description?: string;
   link?: {
-    href: Route;
+    /** Locale-agnostic pathname; the locale prefix is applied by next-intl. */
+    href: string;
     text: string;
     onNavigate?: (e: React.MouseEvent) => void;
   };
@@ -33,7 +31,6 @@ export default function Header({
   link,
   rightContent,
 }: HeaderProps) {
-  const locale = useLocale();
   const resolvedTitle = title || "minpeter";
 
   return (
@@ -51,15 +48,7 @@ export default function Header({
             text={link.text}
           />
         ) : (
-          <Link
-            href={
-              locale === routing.defaultLocale
-                ? ("/" as Route)
-                : (`/${locale}` as Route)
-            }
-          >
-            minpeter
-          </Link>
+          <Link href="/">minpeter</Link>
         )}
         <div className="flex items-center gap-2 text-foreground/80">
           {rightContent}

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -1,6 +1,6 @@
 import { ArrowTopLeftIcon } from "@radix-ui/react-icons";
-import type { Route } from "next";
-import Link from "next/link";
+
+import { Link } from "@/shared/i18n/navigation";
 
 export function Backlink({
   text,
@@ -9,7 +9,8 @@ export function Backlink({
   onNavigate,
 }: {
   text: string;
-  href: Route;
+  /** Locale-agnostic pathname; the locale prefix is applied by next-intl. */
+  href: string;
   ariaLabel?: string;
   onNavigate?: (e: React.MouseEvent) => void;
 }) {

--- a/components/not-found-page.tsx
+++ b/components/not-found-page.tsx
@@ -1,10 +1,13 @@
-import type { Route } from "next";
 import Image from "next/image";
 
 import { LanguageSelector } from "@/components/language-selector";
 
 interface NotFoundPageProps {
-  backHref: Route;
+  /**
+   * Fully localized href: these are plain anchors on purpose (see below), so
+   * the prefix must already be resolved via `getLocalizedPath`.
+   */
+  backHref: string;
   backLabel: string;
   description: string;
   navigationLabel: string;

--- a/components/showcase-detail-header.tsx
+++ b/components/showcase-detail-header.tsx
@@ -1,7 +1,6 @@
-import type { Route } from "next";
 import Image from "next/image";
-import Link from "next/link";
 
+import { Link } from "@/shared/i18n/navigation";
 import { cn } from "@/shared/utils/tailwind";
 
 import { LanguageSelector } from "./language-selector";
@@ -10,7 +9,8 @@ interface ShowcaseDetailHeaderProps {
   backLabel: string;
   className?: string;
   description: string;
-  href: Route;
+  /** Locale-agnostic pathname; the locale prefix is applied by next-intl. */
+  href: string;
   kicker: string;
   navigationLabel: string;
   title: string;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,13 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    server: {
+      deps: {
+        // `next` ships no "exports" map, so its extensionless deep imports
+        // (e.g. `next/navigation`) are unresolvable under Node's ESM loader.
+        // Inlining next-intl routes it through Vite's resolver instead.
+        inline: ["next-intl"],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Problem

Internal links were built by hand as `` `/${locale}${path}` as Route `` in 15 files (home, blog index/detail, showcase index + 6 detail pages, resume, poem page, header, error panel, 404s).

Two concrete problems:

1. **The `as Route` casts defeated `typedRoutes`.** The config enables it (`next.config.mts`), then every locale-aware link opted out of the check.
2. **The hand-built prefix ignored `localePrefix: "as-needed"`.** Korean is the default locale and is served unprefixed, so `/ko/blog` links cost a proxy redirect on every click *and* disagreed with the canonical URL that `createMetadata` emits (`/blog`).

## Change

Internal links now use the locale-aware `Link` from `shared/i18n/navigation` (already existed, barely used) and accept locale-agnostic pathnames — the i18n layer owns prefixing:

```diff
-<Link href={`/${locale}${href}` as Route}>
+<Link href={href}>
```

`Header`, `Backlink` and `ShowcaseDetailHeader` now take `href: string` (documented as locale-agnostic). Callers that only needed `params` for the prefix dropped their `locale` plumbing.

**404 surfaces are deliberately left as plain `<a>`** — the existing comment explains a hard navigation is needed to escape the stale not-found tree — but their href now comes from `getLocalizedPath`, which already honours as-needed, instead of a cast template string.

## Verification

- `pnpm test` 29 files / 115 tests pass (4 href assertions updated from `/ko` → `/`, `/ko/blog` → `/blog`)
- `pnpm check:types`, `pnpm check:oxlint` (173 warnings, identical to `main`), `pnpm build` + `next-sitemap` all clean
- Prerendered HTML confirms prefixing:
  - `/ko/blog` → `href="/"`
  - `/en/blog` → `href="/en"`
  - `/ja/show/tech-stack-ball` → `href="/ja/show"`

## Note on `vitest.config.ts`

`next` ships **no `exports` map**, so its extensionless deep imports (`next/navigation`) can't be resolved by Node's ESM loader once next-intl navigation is imported from a component module. `server.deps.inline: ["next-intl"]` routes it through Vite's resolver. Comment included in the config.

## Follow-up (not in this PR)

fumadocs' loader uses `hideLocale: "never"`, so `post.url` is `/ko/blog/<slug>` even for the default locale — blog list/next/prev links still eat one redirect. Fixing that touches RSS, sitemap, OG routes, the search index and the `.md` rewrite, so it deserves its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all internal links through locale-aware navigation to respect `localePrefix: "as-needed"` and restore `typedRoutes` checks by removing hand-built `/${locale}${path}` prefixes. Also keeps `/resume` and the poem page prerendered per locale via `setRequestLocale`.

- **Refactors**
  - Replaced manual prefixes with `Link` from `shared/i18n/navigation`; all `href`s are now locale-agnostic.
  - Removed `as Route` casts and dropped unnecessary `locale` plumbing in `Header`, `Backlink`, and `ShowcaseDetailHeader`.
  - Kept 404/NotFound as plain anchors; `backHref` now built via `getLocalizedPath`.
  - Test config: inlined `next-intl` in `vitest.config.ts` to resolve `next/navigation` under Node ESM.

- **Bug Fixes**
  - Restored per-locale prerendering and sitemap entries for `/resume` and the poem page by reading `params` and calling `setRequestLocale`.
  - Default `ko` locale now links to unprefixed paths (e.g., `/`, `/blog`) to avoid redirects and match canonical metadata.
  - Re-enabled `typedRoutes` validation by removing unsafe casts.
  - Updated tests for the new hrefs; wrapped the poem page in `NextIntlClientProvider` where needed.

<sup>Written for commit 04eb2751481c7b0ca1f2af6586745d11b1771d08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/85?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

