### PR TITLE
fix(footer): read labels from the message catalog

### DIFF
--- a/components/__tests__/footer.test.tsx
+++ b/components/__tests__/footer.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import type * as intlServer from "next-intl/server";
+import { describe, expect, it, vi } from "vitest";
+
+import Footer from "../footer";
+
+const messages: Record<string, string> = {
+  "common.notes": "notes",
+  "common.source": "source",
+  "common.toggleTheme": "Toggle theme",
+};
+
+vi.mock(
+  import("next-intl/server"),
+  () =>
+    ({
+      getTranslations: vi.fn<() => Promise<(key: string) => string>>(() =>
+        Promise.resolve((key: string) => messages[key] ?? key)
+      ),
+    }) as unknown as Partial<typeof intlServer>
+);
+
+const renderFooter = async (locale: string) => render(await Footer({ locale }));
+
+describe("components/footer.tsx", () => {
+  it("labels itself from the message catalog instead of a local map", async () => {
+    await renderFooter("en");
+
+    expect(screen.getByRole("link", { name: "notes" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "source" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Toggle theme" })).toBeDefined();
+  });
+
+  it("prefixes the notes link for non-default locales only", async () => {
+    const { unmount } = await renderFooter("en");
+    expect(
+      screen.getByRole("link", { name: "notes" }).getAttribute("href")
+    ).toBe("/en/blog");
+    unmount();
+
+    await renderFooter("ko");
+    expect(
+      screen.getByRole("link", { name: "notes" }).getAttribute("href")
+    ).toBe("/blog");
+  });
+
+  it("falls back to the default locale for unknown locale segments", async () => {
+    await renderFooter("de");
+
+    expect(
+      screen.getByRole("link", { name: "notes" }).getAttribute("href")
+    ).toBe("/blog");
+  });
+});

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,28 +1,24 @@
+import { getTranslations } from "next-intl/server";
 import Link from "next/link";
 
+import { routing } from "@/shared/i18n/routing";
+import { resolveLocale } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
 
 import { ModeToggle } from "./theme-toggle";
 
-const FOOTER_LABELS = {
-  en: { notes: "notes", source: "source", toggleTheme: "Toggle theme" },
-  ja: {
-    notes: "記事",
-    source: "ソース",
-    toggleTheme: "テーマを切り替え",
-  },
-  ko: { notes: "글", source: "소스", toggleTheme: "테마 전환" },
-} as const;
+const linkClassName =
+  "underline decoration-foreground/30 underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
 
-export default function Footer({
+export default async function Footer({
   className,
   locale,
 }: {
   className?: string;
   locale: string;
 }) {
-  const labels =
-    FOOTER_LABELS[locale as keyof typeof FOOTER_LABELS] ?? FOOTER_LABELS.ko;
+  const resolvedLocale = resolveLocale(locale);
+  const t = await getTranslations({ locale: resolvedLocale });
 
   return (
     <footer
@@ -34,22 +30,26 @@ export default function Footer({
       <p className="font-mono text-[11px] text-muted-foreground uppercase tracking-[0.08em]">
         © {new Date().getFullYear()} Woonggi Min ·
         <Link
-          className="underline decoration-foreground/30 underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          href={locale === "ko" ? "/blog" : `/${locale}/blog`}
+          className={linkClassName}
+          href={
+            resolvedLocale === routing.defaultLocale
+              ? "/blog"
+              : `/${resolvedLocale}/blog`
+          }
         >
-          {labels.notes}
+          {t("common.notes")}
         </Link>
         {" / "}
         <a
-          className="underline decoration-foreground/30 underline-offset-4 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={linkClassName}
           href="https://github.com/minpeter/minpeter.v2"
           rel="noopener noreferrer"
           target="_blank"
         >
-          {labels.source}
+          {t("common.source")}
         </a>
       </p>
-      <ModeToggle label={labels.toggleTheme} />
+      <ModeToggle label={t("common.toggleTheme")} />
     </footer>
   );
 }


### PR DESCRIPTION
## Problem

`components/footer.tsx` shipped its own translation table:

```ts
const FOOTER_LABELS = {
  en: { notes: "notes", source: "source", toggleTheme: "Toggle theme" },
  ja: { notes: "記事", source: "ソース", toggleTheme: "テーマを切り替え" },
  ko: { notes: "글", source: "소스", toggleTheme: "테마 전환" },
} as const;
```

…while `shared/i18n/{ko,en,ja}.json` already defined `common.notes`, `common.source` and `common.toggleTheme` — **with byte-identical values** (verified before the change). Two sources of truth, only one of which a translator would ever look at.

The default-locale branch also hardcoded `"ko"` instead of using `routing.defaultLocale`.

## Change

- Footer became an async server component and reads the catalog via `getTranslations()`
- `resolveLocale()` narrows the incoming `locale: string` to the `Locale` union, and preserves the old `?? FOOTER_LABELS.ko` fallback semantics for unknown segments
- `"ko"` → `routing.defaultLocale`
- Repeated link classes hoisted to one `linkClassName` constant (they were duplicated verbatim)

## Why `next/link` and not next-intl's locale-aware `Link`

Deliberate: `root-document.tsx` renders `<Footer>` **outside** `NextIntlClientProvider`, and next-intl's `BaseLink` calls `useLocale()` on the client — it would throw "No intl context found" on hydration. `app/global-not-found.tsx` renders `RootDocument` with no provider at all. The explicit prefix ternary stays, now driven by `routing.defaultLocale`.

## Tests

New `components/__tests__/footer.test.tsx` (3 cases):
- labels come from the catalog, not a local map
- `/en/blog` for `en`, `/blog` for `ko` (as-needed prefix)
- unknown locale (`de`) falls back to the default locale

`pnpm test` 30 files / 118 tests pass · `check:types`, `check:oxlint` (173 warnings, same as `main`) and `pnpm build` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Footer to use the shared i18n message catalog and fixes locale-aware blog link routing. Removes the duplicate `FOOTER_LABELS` and falls back to the default locale for unknown segments.

- **Bug Fixes**
  - Made Footer an async server component that reads labels via `getTranslations()` from `next-intl/server`.
  - Builds the notes link with `resolveLocale()` and `routing.defaultLocale`; prefixes only for non-default locales and falls back on unknown locales.
  - Kept `next/link` (not next-intl’s locale `Link`) since Footer renders outside `NextIntlClientProvider`.
  - Added tests for label sourcing, link prefixing, and default-locale fallback.

<sup>Written for commit 5be65a21da7779f2498e1bd661645b5ebbad3a5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

