### PR TITLE
refactor(sitemap): derive locales from one shared module

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,14 +1,17 @@
 /** @type {import('next-sitemap').IConfig} */
 
+import { defaultLocale, locales } from "./shared/i18n/locales.js";
+
 const SITE_URL = process.env.SITE_URL || "https://minpeter.com";
 
-// IMPORTANT: Keep in sync with shared/i18n/routing.ts
-// These values are duplicated here because next-sitemap.config.js is CommonJS
-const locales = ["en", "ko", "ja"];
-const defaultLocale = "ko";
+const defaultLocalePrefix = `/${defaultLocale}`;
 
-// Regex for matching internal Next.js hash paths
-const hashPathPattern = /^(\/(ko|en|ja))?\/[a-f0-9]{32,}/;
+// Internal Next.js hash paths (e.g. the unlisted poem route), optionally
+// locale-prefixed, must stay out of the sitemap.
+const hashPathPattern = new RegExp(
+  `^(/(${locales.join("|")}))?/[a-f0-9]{32,}`,
+  "u"
+);
 
 /**
  * Get priority based on path
@@ -16,7 +19,7 @@ const hashPathPattern = /^(\/(ko|en|ja))?\/[a-f0-9]{32,}/;
  * @returns {number}
  */
 function getPriority(path) {
-  if (path === "/" || path === "/en" || path === "/ja") {
+  if (homepagePaths.has(path)) {
     return 1;
   }
   if (path.includes("/blog")) {
@@ -54,6 +57,12 @@ function getLocalizedPath(basePath, locale) {
   }
   return basePath === "/" ? `/${locale}` : `/${locale}${basePath}`;
 }
+
+// `localePrefix: "as-needed"` means the default locale is served unprefixed, so
+// the homepage exists once per locale: "/", "/en", "/ja".
+const homepagePaths = new Set(
+  locales.map((locale) => getLocalizedPath("/", locale))
+);
 
 /**
  * Generate alternateRefs for hreflang tags
@@ -102,19 +111,19 @@ const config = {
   siteUrl: SITE_URL,
 
   // Transform function to handle localePrefix: "as-needed"
-  // Korean (default) has no prefix, English and Japanese have prefixes
+  // The default locale has no prefix, every other locale keeps one
   transform: (sitemapConfig, path) => {
     // Skip internal Next.js paths (hash-like paths, _next, etc.)
     if (hashPathPattern.test(path)) {
       return null;
     }
 
-    // Transform /ko/* paths to paths without prefix (Korean is default locale)
+    // Strip the default-locale prefix: "/ko/blog/post" -> "/blog/post"
     let loc = path;
-    if (path.startsWith("/ko/")) {
-      loc = path.slice(3); // "/ko/blog/post" -> "/blog/post"
-    } else if (path === "/ko") {
+    if (path === defaultLocalePrefix) {
       loc = "/";
+    } else if (path.startsWith(`${defaultLocalePrefix}/`)) {
+      loc = path.slice(defaultLocalePrefix.length);
     }
 
     const basePath = getBasePath(path);

--- a/next-sitemap.config.test.ts
+++ b/next-sitemap.config.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import sitemapConfig from "./next-sitemap.config.js";
+import { defaultLocale, locales } from "./shared/i18n/locales.js";
+import { routing } from "./shared/i18n/routing";
+
+interface SitemapEntry {
+  alternateRefs: { href: string; hreflang: string }[];
+  changefreq: string;
+  loc: string;
+  priority: number;
+}
+
+const transform = (path: string) =>
+  (sitemapConfig.transform as (config: object, path: string) => SitemapEntry)(
+    {},
+    path
+  );
+
+describe("next-sitemap.config.js", () => {
+  it("derives its locales from the same module as next-intl routing", () => {
+    // The guard this file exists for: the sitemap used to re-declare the
+    // locale list, so adding a locale silently produced a sitemap missing it.
+    expect([...locales]).toStrictEqual([...routing.locales]);
+    expect(defaultLocale).toBe(routing.defaultLocale);
+  });
+
+  it("strips the default-locale prefix", () => {
+    expect(transform(`/${defaultLocale}/blog/post`).loc).toBe("/blog/post");
+    expect(transform(`/${defaultLocale}`).loc).toBe("/");
+  });
+
+  it("keeps the prefix for non-default locales", () => {
+    expect(transform("/en/blog/post").loc).toBe("/en/blog/post");
+    expect(transform("/ja").loc).toBe("/ja");
+  });
+
+  it("emits one hreflang per locale plus x-default", () => {
+    const { alternateRefs } = transform("/en/blog/post");
+
+    expect(alternateRefs.map((ref) => ref.hreflang)).toStrictEqual([
+      ...locales,
+      "x-default",
+    ]);
+    expect(alternateRefs.at(-1)?.href).toBe("https://minpeter.com/blog/post");
+  });
+
+  it("ranks every localized homepage as the top priority", () => {
+    for (const locale of locales) {
+      const path = locale === defaultLocale ? "/" : `/${locale}`;
+      expect(transform(path).priority).toBe(1);
+    }
+  });
+
+  it("ranks blog paths above other pages", () => {
+    expect(transform("/en/blog/post").priority).toBe(0.8);
+    expect(transform("/en/show").priority).toBe(0.7);
+  });
+
+  it("drops unlisted hash routes for every locale", () => {
+    const hash = "a".repeat(32);
+
+    expect(transform(`/${hash}`)).toBeNull();
+    for (const locale of locales) {
+      expect(transform(`/${locale}/${hash}`)).toBeNull();
+    }
+  });
+});

--- a/shared/i18n/locales.js
+++ b/shared/i18n/locales.js
@@ -1,0 +1,19 @@
+// @ts-check
+/**
+ * Single source of truth for the locales this site serves.
+ *
+ * Deliberately plain JavaScript: `next-sitemap.config.js` is loaded by Node
+ * itself and cannot import TypeScript, while `shared/i18n/routing.ts` needs the
+ * string literals to survive so `(typeof routing.locales)[number]` stays a
+ * union rather than `string`.
+ *
+ * `@ts-check` is load-bearing: the repo compiles with `checkJs: false`, so
+ * without it TypeScript would trust the annotations blindly and a value/type
+ * mismatch below could ship silently.
+ */
+
+/** @type {readonly ["en", "ko", "ja"]} */
+export const locales = ["en", "ko", "ja"];
+
+/** @type {"ko"} */
+export const defaultLocale = "ko";

--- a/shared/i18n/routing.ts
+++ b/shared/i18n/routing.ts
@@ -1,5 +1,7 @@
 import { defineRouting } from "next-intl/routing";
 
+import { defaultLocale, locales } from "./locales.js";
+
 const LOCALE_COOKIE_NAME = "MINPETER-LOCATE";
 
 const DAYS_IN_MONTH = 30;
@@ -7,7 +9,7 @@ const LOCALE_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * DAYS_IN_MONTH;
 
 export const routing = defineRouting({
   // Used when no locale matches
-  defaultLocale: "ko",
+  defaultLocale,
 
   localeCookie: {
     maxAge: LOCALE_COOKIE_MAX_AGE_SECONDS,
@@ -18,6 +20,6 @@ export const routing = defineRouting({
   },
 
   localePrefix: "as-needed",
-  // A list of all locales that are supported
-  locales: ["en", "ko", "ja"],
+  // A list of all locales that are supported (shared with next-sitemap.config.js)
+  locales,
 });


### PR DESCRIPTION
## Problem

`next-sitemap.config.js` opened with:

```js
// IMPORTANT: Keep in sync with shared/i18n/routing.ts
// These values are duplicated here because next-sitemap.config.js is CommonJS
const locales = ["en", "ko", "ja"];
const defaultLocale = "ko";
```

Two things wrong with that:

1. **The stated reason no longer holds.** `package.json` is `"type": "module"` and the file already ends in `export default config` — it's ESM and *can* import.
2. **The list was duplicated four more times inside the same file:** the `locales` array, the `(ko|en|ja)` alternation in `hashPathPattern`, the `/en` / `/ja` literals in `getPriority`, and the hardcoded `/ko/` stripping with a magic `slice(3)`.

Adding a locale therefore meant editing five places, and forgetting one would silently ship a sitemap missing hreflang entries — no test, no type error.

## Change

New `shared/i18n/locales.js` is the single source, consumed by both `shared/i18n/routing.ts` and `next-sitemap.config.js`:

```js
// @ts-check
/** @type {readonly ["en", "ko", "ja"]} */
export const locales = ["en", "ko", "ja"];

/** @type {"ko"} */
export const defaultLocale = "ko";
```

**Why plain JS:** Node loads the sitemap config directly and can't import TypeScript, while `routing.ts` needs the literals to survive so `(typeof routing.locales)[number]` stays `"en" | "ko" | "ja"` (used by `Locale` in `types/intl.d.ts`, `z.enum(routing.locales)` in `source.config.ts`, `siteConfig.description`, …).

**Why `@ts-check`:** the repo compiles with `checkJs: false`, so without it tsc would trust the annotations blindly. Verified it bites — dropping `"ja"` from the value produces:

```
shared/i18n/locales.js(16,14): error TS2322: Type '["en", "ko"]' is not assignable to type 'readonly ["en", "ko", "ja"]'.
```

Everything else in the config is now derived: the regex alternation, the homepage set (`homepagePaths`), and the default-prefix stripping (`defaultLocalePrefix.length` instead of `slice(3)`).

## Verification

Behavioural equivalence proven against a `main`-based build of the same commit: **`public/sitemap.xml` (202 URLs) and `public/robots.txt` are byte-identical** apart from `lastmod` timestamps.

New `next-sitemap.config.test.ts` (7 cases) locks the behaviour in and adds the drift guard the comment could only ask for:

```ts
expect([...locales]).toStrictEqual([...routing.locales]);
expect(defaultLocale).toBe(routing.defaultLocale);
```

plus prefix stripping, hreflang set + `x-default`, per-locale homepage priority, blog priority, and hash-route exclusion for every locale.

`pnpm test` 30 files / 122 tests · `check:types` · `check:oxlint` (170 warnings, 3 fewer than `main`) · `pnpm build` + `next-sitemap` all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored locale handling to a single shared source so `next-sitemap` and `next-intl` routing both derive `locales` and `defaultLocale` from one module. This removes duplication and prevents sitemap drift when adding locales; sitemap/robots output remains unchanged.

- **Refactors**
  - Added `shared/i18n/locales.js` (plain JS with `@ts-check`) exporting `locales` and `defaultLocale`.
  - `next-sitemap.config.js` and `shared/i18n/routing.ts` now import from the shared module.
  - Derived regex alternation, homepage set, and default-locale prefix stripping from `locales`/`defaultLocale` (no hardcoded `/ko`, `/en`, `/ja`).
  - Added `next-sitemap.config.test.ts` to guard locale sync, default-prefix stripping, hreflang set (incl. `x-default`), homepage/blog priorities, and hash-route exclusion.

<sup>Written for commit 2f32fddded6f36ce222f071d23449b0a2b16fdb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/87?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

