### PR TITLE
refactor(blog): drop the empty itemStyles placeholder

### DIFF
--- a/app/[locale]/blog/list-fallback.tsx
+++ b/app/[locale]/blog/list-fallback.tsx
@@ -11,6 +11,11 @@ import { cn } from "@/shared/utils/tailwind";
 
 import styles from "@/shared/styles/stagger-fade-in.module.css";
 
+// Shared by the external-link and internal-link branches of a list item.
+const ITEM_LINK_CLASSNAME =
+  "fieldnotes-item-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const ITEM_TITLE_CLASSNAME = "fieldnotes-item-title line-clamp-2";
+
 export function BlogSearchShell({
   searchPlaceholder,
 }: {
@@ -58,8 +63,6 @@ export function BlogListFallback({
     {}
   );
 
-  const itemStyles = "";
-
   return (
     <div
       aria-busy={isLoading || undefined}
@@ -85,20 +88,12 @@ export function BlogListFallback({
                   <li className="fieldnotes-item" key={post.url}>
                     {post.external_url ? (
                       <a
-                        className={cn(
-                          itemStyles,
-                          "fieldnotes-item-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        )}
+                        className={ITEM_LINK_CLASSNAME}
                         href={post.external_url}
                         rel="noopener noreferrer"
                         target="_blank"
                       >
-                        <span
-                          className={cn(
-                            "fieldnotes-item-title line-clamp-2",
-                            itemStyles
-                          )}
-                        >
+                        <span className={ITEM_TITLE_CLASSNAME}>
                           {post.title}
                           <ExternalLink
                             className="ml-1 inline-block pb-1 opacity-60"
@@ -120,22 +115,14 @@ export function BlogListFallback({
                       </a>
                     ) : (
                       <Link
-                        className={cn(
-                          itemStyles,
-                          "fieldnotes-item-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                        )}
+                        className={ITEM_LINK_CLASSNAME}
                         href={post.url as Route}
                         prefetch={false}
                       >
                         <ViewTransition
                           name={`blog-title-${post.url.replaceAll("/", "-")}`}
                         >
-                          <span
-                            className={cn(
-                              "fieldnotes-item-title line-clamp-2",
-                              itemStyles
-                            )}
-                          >
+                          <span className={ITEM_TITLE_CLASSNAME}>
                             {post.title}
                           </span>
                         </ViewTransition>


### PR DESCRIPTION
## Problem

`app/[locale]/blog/list-fallback.tsx` carried:

```ts
const itemStyles = "";
```

…threaded through **four** `cn()` calls. Since `cn("", "a b") === cn("a b", "") === "a b"`, every one of those calls was a no-op wrapper around a static string — a `clsx` + `tailwind-merge` round trip per list item, per render, for nothing.

## Change

- `itemStyles` removed along with the four `cn()` wrappers it justified
- The two class strings it was interleaved with **are** genuinely shared between the external-link and internal-link branches of a list item (repeated verbatim), which is presumably what the placeholder was reaching for — they're now `ITEM_LINK_CLASSNAME` / `ITEM_TITLE_CLASSNAME` constants

`cn` is still used for the container and year list, where it actually composes.

## Verification

Rendered output unchanged — the multiset of `class` attributes in the prerendered `/{ko,en,ja}/blog` HTML is identical to a `main` build (remaining HTML diff is just per-worktree chunk hashes).

`pnpm test` 115 tests · `check:types` · `check:oxlint` (173 warnings, same as `main`) · `pnpm build` clean.

## Note

`pnpm knip` also reports `components/ui/aspect-ratio.tsx`, the `next-intl` navigation re-exports and `doctor.config.ts` — all deliberate and already justified in `doctor.config.ts`, so they're left alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the empty itemStyles placeholder in the blog list fallback and deleted four no-op cn() wrappers around static class strings. Introduced ITEM_LINK_CLASSNAME and ITEM_TITLE_CLASSNAME for shared classes; rendered output is unchanged and cn remains only where it composes.

<sup>Written for commit 5014ce77d7c68fcfbd36908ed5c40aba6d13881e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

