### PR TITLE
refactor(i18n): migrate setRequestLocale to next/root-params

### DIFF
--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/__tests__/poem-page.test.tsx
@@ -10,8 +10,8 @@ vi.mock(
   import("next-intl/server"),
   () =>
     ({
+      getLocale: vi.fn(() => Promise.resolve("ko")),
       getTranslations: vi.fn(() => (key: string) => key),
-      setRequestLocale: vi.fn<() => void>(),
     }) as unknown as Partial<typeof intlServer>
 );
 
@@ -21,10 +21,7 @@ vi.mock(import("@/shared/styles/stagger-fade-in.module.css"), () => ({
 
 describe("app/[locale]/73e3da.../page.tsx poem", () => {
   it("separates the backlink from the poem content with clear spacing", async () => {
-    const ui = await Page({
-      params: Promise.resolve({ locale: "ko" }),
-      searchParams: Promise.resolve({}),
-    });
+    const ui = await Page();
 
     // The backlink resolves its locale prefix through next-intl navigation.
     const { container } = render(

--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
@@ -1,20 +1,17 @@
 import type { Metadata } from "next";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { Backlink } from "@/components/link";
 import styles from "@/shared/styles/stagger-fade-in.module.css";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
 
 // Cache Components opt-out — remove after this route is adopted.
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
 
   return createMetadata({
     description: "동짓달 기나긴 밤을 한 허리를 베어내어",
@@ -24,13 +21,7 @@ export async function generateMetadata(
   });
 }
 
-export default async function Page(
-  props: PageProps<"/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257">
-) {
-  const { locale } = await props.params;
-  // Opts the page into static rendering: a page that never reads `params`
-  // drops out of the per-locale prerender manifest.
-  setRequestLocale(resolveLocale(locale));
+export default async function Page() {
   const t = await getTranslations();
   return (
     <section className="flex flex-col gap-6">

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,21 +1,13 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
-import {
-  getMessages,
-  getTranslations,
-  setRequestLocale,
-} from "next-intl/server";
+import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
 import { ViewTransition } from "@/components/view-transition";
 import { routing } from "@/shared/i18n/routing";
 import { getSiteDescription } from "@/shared/site-config";
-import {
-  createMetadata,
-  getLocalizedPath,
-  resolveLocale,
-} from "@/shared/utils/metadata";
+import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 
 import "../globals.css";
 import { RootDocument } from "../root-document";
@@ -39,10 +31,9 @@ export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { locale: routeLocale } = await params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations();
   const baseMetadata = createMetadata({
     description: getSiteDescription(locale),
     locale,
@@ -69,14 +60,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function LocaleLayout({ children, params }: Props) {
-  const { locale } = await params;
+  const { locale: routeLocale } = await params;
 
-  if (!hasLocale(routing.locales, locale)) {
+  if (!hasLocale(routing.locales, routeLocale)) {
     notFound();
   }
 
-  setRequestLocale(locale);
-  const messages = await getMessages();
+  const [locale, messages] = await Promise.all([getLocale(), getMessages()]);
 
   return (
     <RootDocument lang={locale}>

--- a/app/[locale]/resume/page.tsx
+++ b/app/[locale]/resume/page.tsx
@@ -1,21 +1,18 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { getTranslations, setRequestLocale } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { LanguageSelector } from "@/components/language-selector";
 import { Link } from "@/shared/i18n/navigation";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 // Cache Components opt-out — remove after this route is adopted.
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/resume">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getLocale();
+  const t = await getTranslations();
 
   return createMetadata({
     description: t("resume.metadataDescription"),
@@ -25,11 +22,7 @@ export async function generateMetadata(
   });
 }
 
-export default async function Page(props: PageProps<"/[locale]/resume">) {
-  const { locale } = await props.params;
-  // Opts the page into static rendering: a page that never reads `params`
-  // drops out of the per-locale prerender manifest (and thus the sitemap).
-  setRequestLocale(resolveLocale(locale));
+export default async function Page() {
   const t = await getTranslations();
 
   return (

--- a/shared/i18n/request.ts
+++ b/shared/i18n/request.ts
@@ -1,4 +1,5 @@
 import deepmerge from "deepmerge";
+import { locale as getRootLocale } from "next/root-params";
 import type { Formats } from "next-intl";
 import { hasLocale } from "next-intl";
 import { getRequestConfig } from "next-intl/server";
@@ -26,12 +27,25 @@ export const formats = {
   },
 } satisfies Formats;
 
-export default getRequestConfig(async ({ requestLocale }) => {
-  // Typically corresponds to the `[locale]` segment
-  const requested = await requestLocale;
-  const locale = hasLocale(routing.locales, requested)
-    ? requested
-    : routing.defaultLocale;
+async function resolveLocale(explicit?: string) {
+  if (hasLocale(routing.locales, explicit)) {
+    return explicit;
+  }
+
+  // Prefer native root params (Next 16.3+) so static rendering and Cache
+  // Components work without setRequestLocale. Falls back for global-not-found
+  // and other trees outside `[locale]`.
+  // See: https://next-intl.dev/blog/nextjs-root-params
+  const paramValue = await getRootLocale();
+  if (hasLocale(routing.locales, paramValue)) {
+    return paramValue;
+  }
+
+  return routing.defaultLocale;
+}
+
+export default getRequestConfig(async ({ locale: explicitLocale }) => {
+  const locale = await resolveLocale(explicitLocale);
 
   // If current locale is not the default, merge with fallback messages
   // This ensures missing translations fall back to the default locale (ko)


### PR DESCRIPTION
## Summary
Closes #93.

- `shared/i18n/request.ts` resolves locale from `next/root-params` (with explicit override + defaultLocale fallback)
- Remove all `setRequestLocale` call sites (layout, resume, poem)
- Prefer `getLocale()` / `getTranslations()` without manual `{ locale }` where root-params applies
- Keep `generateStaticParams` + invalid-locale `notFound()` in `[locale]/layout`

## Test plan
- [x] `pnpm check:lint` / `pnpm check:types` / `pnpm test` / `pnpm build`
- [ ] Locale switcher + default/non-default locales on preview
- [ ] Blog list/post soft-nav under Cache Components

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates locale detection to `next/root-params` and removes `setRequestLocale` across `[locale]` routes. Pages and metadata now use `getLocale()`/`getTranslations()` to enable static rendering and work cleanly with Cache Components.

- **Refactors**
  - `shared/i18n/request.ts`: resolve locale via `next/root-params` with explicit override and default fallback; keep fallback message merging.
  - `[locale]/layout`: validate `params.locale`, use `getLocale()`/`getTranslations()` for metadata, load messages with `getMessages()`, remove `setRequestLocale`; keep `generateStaticParams` and `notFound()` for invalid locales.
  - Poem and Resume pages (+ tests): stop reading `params` and using `setRequestLocale`; rely on `getLocale()`/`getTranslations()`; simplify test setup.

<sup>Written for commit f75c54c6ff8b3086c2e0378800c335edc523a079. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

