### PR TITLE
feat: Cache Components shells + remaining deprecations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ public/robots.txt
 shared/i18n/*.d.json.ts
 .omx/
 .omo/
+
+# Playwright
+test-results/
+playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,15 @@
 
 ## Cache Components
 - `cacheComponents: true` and `partialPrefetching: true` in `next.config.mts` (stable top-level).
-- Prefer removing `instant = false` once a route builds clean. Interactive showcases may keep a deliberate Block (client-only canvas / timers / network).
+- Prefer no `instant = false`; interactive islands are client components under Suspense.
 - Blog list: server shell renders post list; client `BlogList` only owns search (`?q=`).
 - OG routes use `"use cache"` + `cacheLife("days")` instead of `revalidate`/`dynamic`.
+
+## Instant soft-nav e2e (`@next/playwright`)
+- Rig: `instant-nav.rig.md`
+- Measure only production builds with `EXPOSE_TESTING_API=1` (sets `experimental.exposeTestingApiInProductionBuild`).
+- Run: `pnpm test:e2e:instant` (build + playwright) or `pnpm build` with the env var then `pnpm test:e2e`.
+- Specs: `e2e/soft-nav.instant.spec.ts` (home→blog, blog→post, showcase detail).
 
 ## Next experimental flags (`next.config.mts`)
 Keep under `experimental` until they gain a stable top-level rename (Next 16.3 types still list these as experimental-only):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,28 @@
 - Typecheck: `pnpm check` · Tests: `pnpm test` · Build: `pnpm build` · Audit: `pnpm audit --prod`
 
 ## Cache Components
-- `cacheComponents: true` and `partialPrefetching: true` in `next.config.mts`.
-- Most pages/layouts still export `instant = false` with "Cache Components opt-out" markers — do not remove without verifying the route shell in dev/build.
+- `cacheComponents: true` and `partialPrefetching: true` in `next.config.mts` (stable top-level).
+- Prefer removing `instant = false` once a route builds clean. Interactive showcases may keep a deliberate Block (client-only canvas / timers / network).
+- Blog list: server shell renders post list; client `BlogList` only owns search (`?q=`).
 - OG routes use `"use cache"` + `cacheLife("days")` instead of `revalidate`/`dynamic`.
+
+## Next experimental flags (`next.config.mts`)
+Keep under `experimental` until they gain a stable top-level rename (Next 16.3 types still list these as experimental-only):
+- `experimental.globalNotFound`
+- `experimental.useTypeScriptCli`
+- `experimental.optimizePackageImports` (`lucide-react`, `@radix-ui/react-icons`, `react-icons`)
+
+## i18n: Server Components vs Route Handlers
+- **Server Components / `generateMetadata` under `[locale]`**: prefer request locale from next-intl (root-params), not params override:
+  ```ts
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
+  ```
+- **Keep explicit `{ locale }`** for opengraph-image / twitter-image routes and true Route Handlers (rss, og handlers) where root-params may be unreliable.
+- **Route Handlers / Server Actions**: `next/root-params` does **not** work. Pass locale explicitly:
+  ```ts
+  // Route Handlers / Server Actions: next/root-params does NOT work.
+  // Pass locale explicitly:
+  const t = await getTranslations({ locale });
+  // getRequestConfig receives { locale } override when provided
+  // (shared/i18n/request.ts resolveLocale(explicit)).
+  ```

--- a/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
+++ b/app/[locale]/73e3da8fa7a397e7b1bc36efabb2cbb265524a75d7d5e6d1620b9e10e694257/page.tsx
@@ -6,10 +6,6 @@ import styles from "@/shared/styles/stagger-fade-in.module.css";
 import { createMetadata } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
 

--- a/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
+++ b/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
@@ -130,5 +130,3 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
     expect(panel?.className).not.toContain("min-h-dvh");
   });
 });
-
-

--- a/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
+++ b/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
@@ -15,6 +15,7 @@ vi.mock(
   import("next-intl/server"),
   () =>
     ({
+      getLocale: vi.fn(() => Promise.resolve("ko")),
       getTranslations: vi.fn(() => (key: string) => {
         const messages: Record<string, string> = {
           backToBlog: "글 목록으로",
@@ -73,7 +74,7 @@ vi.mock(import("../post-toc"), () => ({ PostToc: () => <div /> }));
 
 describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
   it("keeps the header chrome with a back-to-blog link around the redirect", async () => {
-    const ui = await Page({
+    const ui = Page({
       params: Promise.resolve({ locale: "ko", slug: ["external-post"] }),
       searchParams: Promise.resolve({}),
     });
@@ -92,12 +93,12 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
       </NextIntlClientProvider>
     );
 
-    const backLink = screen.getByRole("link", { name: "글 목록으로" });
+    const backLink = await screen.findByRole("link", { name: "글 목록으로" });
     expect(backLink.getAttribute("href")).toBe("/blog");
   });
 
   it("keeps the redirect panel inside one viewport under the header", async () => {
-    const ui = await Page({
+    const ui = Page({
       params: Promise.resolve({ locale: "ko", slug: ["external-post"] }),
       searchParams: Promise.resolve({}),
     });
@@ -116,7 +117,8 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
       </NextIntlClientProvider>
     );
 
-    const section = container.querySelector("section");
+    const countdown = await screen.findByText(COUNTDOWN_RE);
+    const section = container.querySelector("section.blog-post-page");
     expect(section?.className).toContain("flex-1");
     expect(section?.className).toContain("flex-col");
     expect(section?.className).not.toContain("min-h-dvh");
@@ -125,9 +127,9 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
     // the space between header and footer without adding scroll.
     expect(container.querySelectorAll(".min-h-dvh")).toHaveLength(0);
 
-    const countdown = screen.getByText(COUNTDOWN_RE);
     const panel = countdown.closest("div.flex-1");
     expect(panel).not.toBeNull();
     expect(panel?.className).not.toContain("min-h-dvh");
   });
 });
+

--- a/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
+++ b/app/[locale]/blog/[...slug]/__tests__/external-post-chrome.test.tsx
@@ -8,7 +8,7 @@ import { describe, expect, it, vi } from "vitest";
 import type * as sourceModule from "@/shared/source";
 
 import type * as mdxComponentsModule from "../mdx-components";
-import Page from "../page";
+import { PostBody } from "../page";
 
 const COUNTDOWN_RE = /초 후 외부 링크로 이동합니다/;
 vi.mock(
@@ -74,9 +74,8 @@ vi.mock(import("../post-toc"), () => ({ PostToc: () => <div /> }));
 
 describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
   it("keeps the header chrome with a back-to-blog link around the redirect", async () => {
-    const ui = Page({
+    const ui = await PostBody({
       params: Promise.resolve({ locale: "ko", slug: ["external-post"] }),
-      searchParams: Promise.resolve({}),
     });
 
     render(
@@ -93,14 +92,13 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
       </NextIntlClientProvider>
     );
 
-    const backLink = await screen.findByRole("link", { name: "글 목록으로" });
+    const backLink = screen.getByRole("link", { name: "글 목록으로" });
     expect(backLink.getAttribute("href")).toBe("/blog");
   });
 
   it("keeps the redirect panel inside one viewport under the header", async () => {
-    const ui = Page({
+    const ui = await PostBody({
       params: Promise.resolve({ locale: "ko", slug: ["external-post"] }),
-      searchParams: Promise.resolve({}),
     });
 
     const { container } = render(
@@ -117,7 +115,6 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
       </NextIntlClientProvider>
     );
 
-    const countdown = await screen.findByText(COUNTDOWN_RE);
     const section = container.querySelector("section.blog-post-page");
     expect(section?.className).toContain("flex-1");
     expect(section?.className).toContain("flex-col");
@@ -127,9 +124,11 @@ describe("app/[locale]/blog/[...slug]/page.tsx external-linked post", () => {
     // the space between header and footer without adding scroll.
     expect(container.querySelectorAll(".min-h-dvh")).toHaveLength(0);
 
+    const countdown = screen.getByText(COUNTDOWN_RE);
     const panel = countdown.closest("div.flex-1");
     expect(panel).not.toBeNull();
     expect(panel?.className).not.toContain("min-h-dvh");
   });
 });
+
 

--- a/app/[locale]/blog/[...slug]/loading.tsx
+++ b/app/[locale]/blog/[...slug]/loading.tsx
@@ -4,7 +4,11 @@ const BODY_LINES = ["line-1", "line-2", "line-3", "line-4", "line-5"] as const;
 
 export default function Loading() {
   return (
-    <section aria-busy="true" className="blog-post-page flex flex-1 flex-col">
+    <section
+      aria-busy="true"
+      className="blog-post-page flex flex-1 flex-col"
+      data-testid="blog-post-shell"
+    >
       <header className="relative z-10 mx-auto mb-16 w-full max-w-2xl border-foreground/20 border-b pb-10 sm:mb-20">
         <div className="flex items-center justify-between font-mono text-[11px] uppercase tracking-[-0.05em]">
           <Skeleton className="h-4 w-24 rounded-sm" />

--- a/app/[locale]/blog/[...slug]/not-found.tsx
+++ b/app/[locale]/blog/[...slug]/not-found.tsx
@@ -4,10 +4,6 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { NotFoundPage } from "@/components/not-found-page";
 import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 

--- a/app/[locale]/blog/[...slug]/page.tsx
+++ b/app/[locale]/blog/[...slug]/page.tsx
@@ -1,6 +1,6 @@
 import { DocsBody } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import ExternalRedirect from "@/components/external-redirect";
 import Header from "@/components/header";
@@ -9,19 +9,11 @@ import { siteConfig } from "@/shared/site-config";
 import { blog } from "@/shared/source";
 import styles from "@/shared/styles/stagger-fade-in.module.css";
 import { formatDateLong } from "@/shared/utils/date";
-import {
-  createMetadata,
-  getLocalizedPath,
-  resolveLocale,
-} from "@/shared/utils/metadata";
+import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
 import { createBlogMdxComponents } from "./mdx-components";
 import { PostFooter } from "./post-footer";
 import { PostToc } from "./post-toc";
-
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
 
 export function generateStaticParams({
   params,
@@ -36,9 +28,8 @@ export function generateStaticParams({
 export async function generateMetadata(
   props: PageProps<"/[locale]/blog/[...slug]">
 ) {
-  const { locale: rawLocale, slug } = await props.params;
-  const locale = resolveLocale(rawLocale);
-  const t = await getTranslations({ locale });
+  const { slug } = await props.params;
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
   const page = blog.getPage(slug, locale);
   if (!page) {
     return createMetadata({

--- a/app/[locale]/blog/[...slug]/page.tsx
+++ b/app/[locale]/blog/[...slug]/page.tsx
@@ -68,7 +68,8 @@ export async function generateMetadata(
   });
 }
 
-async function PostBody({
+/** Exported for unit tests; page wraps this in Suspense for the soft-nav shell. */
+export async function PostBody({
   params,
 }: {
   params: Promise<{ locale: string; slug: string[] }>;

--- a/app/[locale]/blog/[...slug]/page.tsx
+++ b/app/[locale]/blog/[...slug]/page.tsx
@@ -1,6 +1,7 @@
 import { DocsBody } from "fumadocs-ui/page";
 import { notFound } from "next/navigation";
 import { getLocale, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import ExternalRedirect from "@/components/external-redirect";
 import Header from "@/components/header";
@@ -11,6 +12,8 @@ import styles from "@/shared/styles/stagger-fade-in.module.css";
 import { formatDateLong } from "@/shared/utils/date";
 import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
+
+import Loading from "./loading";
 import { createBlogMdxComponents } from "./mdx-components";
 import { PostFooter } from "./post-footer";
 import { PostToc } from "./post-toc";
@@ -65,10 +68,13 @@ export async function generateMetadata(
   });
 }
 
-export default async function Page(
-  props: PageProps<"/[locale]/blog/[...slug]">
-) {
-  const { locale, slug } = await props.params;
+async function PostBody({
+  params,
+}: {
+  params: Promise<{ locale: string; slug: string[] }>;
+}) {
+  const { locale: routeLocale, slug } = await params;
+  const locale = (await getLocale()) || routeLocale;
   const post = blog.getPage(slug, locale);
 
   if (!post) {
@@ -85,6 +91,7 @@ export default async function Page(
           styles.post,
           "blog-post-page flex flex-1 flex-col"
         )}
+        data-testid="blog-post-shell"
       >
         <Header
           link={{ href: "/blog", text: t("backToBlog") }}
@@ -101,6 +108,7 @@ export default async function Page(
   return (
     <section
       className={cn(styles.stagger_container, styles.post, "blog-post-page")}
+      data-testid="blog-post-shell"
     >
       <Header
         description={formatDateLong(post.data.published)}
@@ -121,6 +129,7 @@ export default async function Page(
         <div
           className="[&_a]:[overflow-wrap:anywhere] [&_code]:[overflow-wrap:anywhere] [&_kbd]:[overflow-wrap:anywhere] [&_samp]:[overflow-wrap:anywhere]"
           data-blog-body=""
+          data-testid="blog-post-content"
           lang={locale}
           style={{
             overflowWrap: "break-word",
@@ -142,5 +151,14 @@ export default async function Page(
         post={post}
       />
     </section>
+  );
+}
+
+export default function Page(props: PageProps<"/[locale]/blog/[...slug]">) {
+  // Keep the segment shell (loading.tsx) instant; stream URL-specific post body.
+  return (
+    <Suspense fallback={<Loading />}>
+      <PostBody params={props.params} />
+    </Suspense>
   );
 }

--- a/app/[locale]/blog/__tests__/metadata.test.tsx
+++ b/app/[locale]/blog/__tests__/metadata.test.tsx
@@ -21,12 +21,15 @@ const dictionaries: Record<string, Record<string, unknown>> = {
   ko: readMessages("ko"),
 };
 
+let mockLocale = "en";
+
 vi.mock(
   import("next-intl/server"),
   () =>
     ({
-      getTranslations: vi.fn((options?: { locale?: string }) => {
-        const dict = dictionaries[options?.locale ?? "en"] ?? dictionaries.en;
+      getLocale: vi.fn(() => Promise.resolve(mockLocale)),
+      getTranslations: vi.fn(() => {
+        const dict = dictionaries[mockLocale] ?? dictionaries.en;
         return (key: string): string => {
           const value = key
             .split(".")
@@ -75,10 +78,8 @@ describe("app/[locale]/blog/page.tsx generateMetadata", () => {
   ])(
     "keeps the site-wide brand prefix and localizes the title for locale %s",
     async (locale, localizedTitle) => {
-      const metadata = await generateMetadata({
-        params: Promise.resolve({ locale }),
-        searchParams: Promise.resolve({}),
-      });
+      mockLocale = locale;
+      const metadata = await generateMetadata();
 
       expect(metadata.title).toBe(`minpeter | ${localizedTitle}`);
     }

--- a/app/[locale]/blog/list-fallback.tsx
+++ b/app/[locale]/blog/list-fallback.tsx
@@ -116,6 +116,7 @@ export function BlogListFallback({
                     ) : (
                       <Link
                         className={ITEM_LINK_CLASSNAME}
+                        data-testid="blog-post-link"
                         href={post.url as Route}
                       >
                         <ViewTransition

--- a/app/[locale]/blog/list.tsx
+++ b/app/[locale]/blog/list.tsx
@@ -5,7 +5,7 @@ import { fetchClient } from "fumadocs-core/search/client/fetch";
 import { Loader2, Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { debounce, parseAsString, useQueryState } from "nuqs";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import {
   useCallback,
   useDeferredValue,
@@ -19,10 +19,17 @@ import type { postMetadataType } from "@/shared/source";
 import { BlogListFallback } from "./list-fallback";
 import { extractMatchedUrls, filterByTitle } from "./post-search";
 
+/**
+ * Client search island: owns the search input and URL `?q=` state.
+ * When the query is empty, renders the server-provided static list (`children`).
+ * When searching, replaces it with a filtered client list.
+ */
 export function BlogList({
+  children,
   lang,
   posts,
 }: {
+  children: ReactNode;
   lang: string;
   posts: postMetadataType[];
 }) {
@@ -70,25 +77,28 @@ export function BlogList({
     setQuery(null);
   }, [setQuery]);
 
-  const byLang = posts.filter((post) => post.lang.includes(lang));
-  let filteredPosts = byLang;
+  const filteredPosts = useMemo(() => {
+    if (!deferredQuery) {
+      return null;
+    }
 
-  if (deferredQuery) {
+    const byLang = posts.filter((post) => post.lang.includes(lang));
+
     if (
       searchQuery.isLoading ||
       searchQuery.data === "empty" ||
       !searchQuery.data
     ) {
-      filteredPosts = filterByTitle(byLang, deferredQuery);
-    } else {
-      const matchedUrls = extractMatchedUrls(searchQuery.data);
-      const bySearchResult = byLang.filter((post) => matchedUrls.has(post.url));
-      filteredPosts =
-        bySearchResult.length === 0
-          ? filterByTitle(byLang, deferredQuery)
-          : bySearchResult;
+      return filterByTitle(byLang, deferredQuery);
     }
-  }
+
+    const matchedUrls = extractMatchedUrls(searchQuery.data);
+    const bySearchResult = byLang.filter((post) => matchedUrls.has(post.url));
+
+    return bySearchResult.length === 0
+      ? filterByTitle(byLang, deferredQuery)
+      : bySearchResult;
+  }, [deferredQuery, lang, posts, searchQuery.data, searchQuery.isLoading]);
 
   return (
     <>
@@ -124,11 +134,15 @@ export function BlogList({
           </div>
         ) : null}
       </div>
-      <BlogListFallback
-        isLoading={isSearching}
-        lang={lang}
-        posts={filteredPosts}
-      />
+      {filteredPosts ? (
+        <BlogListFallback
+          isLoading={isSearching}
+          lang={lang}
+          posts={filteredPosts}
+        />
+      ) : (
+        children
+      )}
     </>
   );
 }

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -40,7 +40,7 @@ export default async function Page() {
   );
 
   return (
-    <section className="fieldnotes-page">
+    <section className="fieldnotes-page" data-testid="blog-list-shell">
       <header className="fieldnotes-header">
         <nav aria-label={t("common.blogNavigation")} className="fieldnotes-nav">
           <Link

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -1,31 +1,19 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 
 import { LanguageSelector } from "@/components/language-selector";
 import { Link } from "@/shared/i18n/navigation";
 import { blog, getPostsMetadata } from "@/shared/source";
-import {
-  createMetadata,
-  getLocalizedPath,
-  resolveLocale,
-} from "@/shared/utils/metadata";
+import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 
 import { BlogList } from "./list";
 import { BlogListFallback, BlogSearchShell } from "./list-fallback";
 import { RssLink } from "./rss-link";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
-export async function generateMetadata(
-  props: PageProps<"/[locale]/blog">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
   const baseMetadata = createMetadata({
     description: t("blogPageDescription"),
     locale,
@@ -44,12 +32,12 @@ export async function generateMetadata(
   };
 }
 
-export default async function Page(props: PageProps<"/[locale]/blog">) {
-  const { locale } = await props.params;
+export default async function Page() {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
-  const posts = getPostsMetadata(blog.getPages(locale));
-
-  const t = await getTranslations();
+  const posts = getPostsMetadata(blog.getPages(locale)).filter((post) =>
+    post.lang.includes(locale)
+  );
 
   return (
     <section className="fieldnotes-page">
@@ -79,6 +67,10 @@ export default async function Page(props: PageProps<"/[locale]/blog">) {
           </div>
         </nav>
       </header>
+      {/*
+        Soft-nav / streaming shell: header + search placeholder + full post list.
+        After hydrate, BlogList keeps the server list (children) until ?q= is set.
+      */}
       <Suspense
         fallback={
           <>
@@ -87,7 +79,9 @@ export default async function Page(props: PageProps<"/[locale]/blog">) {
           </>
         }
       >
-        <BlogList lang={locale} posts={posts} />
+        <BlogList lang={locale} posts={posts}>
+          <BlogListFallback lang={locale} posts={posts} />
+        </BlogList>
       </Suspense>
     </section>
   );

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -16,10 +16,6 @@ import {
   viewport as rootViewport,
 } from "../root-metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export const viewport = rootViewport;
 
 interface Props {

--- a/app/[locale]/not-found.tsx
+++ b/app/[locale]/not-found.tsx
@@ -4,10 +4,6 @@ import { getLocale, getTranslations } from "next-intl/server";
 import { NotFoundPage } from "@/components/not-found-page";
 import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -66,7 +66,12 @@ export default function Page() {
 
       <nav aria-label={t("exploreLabel")} className="home-links">
         {SECTIONS.map(({ descriptionKey, href, titleKey }) => (
-          <Link className="home-link group" href={href} key={href}>
+          <Link
+            className="home-link group"
+            data-testid={`home-link-${href.slice(1)}`}
+            href={href}
+            key={href}
+          >
             <span className="home-link-title">{t(titleKey)}</span>
             <span className="home-link-description">{t(descriptionKey)}</span>
           </Link>

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -3,10 +3,6 @@ import { useTranslations } from "next-intl";
 
 import { Link } from "@/shared/i18n/navigation";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 const SECTIONS = [
   {
     descriptionKey: "sections.developmentNotes.description",

--- a/app/[locale]/resume/page.tsx
+++ b/app/[locale]/resume/page.tsx
@@ -6,10 +6,6 @@ import { LanguageSelector } from "@/components/language-selector";
 import { Link } from "@/shared/i18n/navigation";
 import { createMetadata } from "@/shared/utils/metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export async function generateMetadata(): Promise<Metadata> {
   const locale = await getLocale();
   const t = await getTranslations();

--- a/app/[locale]/show/dynamic-hacked-text/page.tsx
+++ b/app/[locale]/show/dynamic-hacked-text/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import AnimatedText from "./animated-text";
 
-// Cache Components opt-out — remove after this route is adopted.
+// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/dynamic-hacked-text">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.dynamicText.summary"),

--- a/app/[locale]/show/dynamic-hacked-text/page.tsx
+++ b/app/[locale]/show/dynamic-hacked-text/page.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { createMetadata } from "@/shared/utils/metadata";
 
 import AnimatedText from "./animated-text";
-
-// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
@@ -21,13 +19,11 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-export default async function Page(
-  _props: PageProps<"/[locale]/show/dynamic-hacked-text">
-) {
+export default async function Page() {
   const t = await getTranslations();
 
   return (
-    <section className="showcase-page">
+    <section className="showcase-page" data-testid="showcase-detail-shell">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.dynamicText.description")}
@@ -40,7 +36,9 @@ export default async function Page(
       />
 
       <div className="flex min-h-56 items-center justify-center rounded-lg border border-foreground/10 bg-secondary/35 px-5">
-        <AnimatedText data={"Hello world"} />
+        <Suspense fallback={<Skeleton className="h-10 w-48" />}>
+          <AnimatedText data={"Hello world"} />
+        </Suspense>
       </div>
     </section>
   );

--- a/app/[locale]/show/model-card-artwork/page.tsx
+++ b/app/[locale]/show/model-card-artwork/page.tsx
@@ -1,22 +1,14 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import { modelCardArtworks } from "./assets";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/model-card-artwork">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.modelCard.summary"),

--- a/app/[locale]/show/new-year-clock/layout.tsx
+++ b/app/[locale]/show/new-year-clock/layout.tsx
@@ -1,22 +1,19 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import type { ReactNode } from "react";
 
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
+// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
 interface Props {
   children: ReactNode;
-  params: Promise<{ locale: string }>;
 }
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { locale: routeLocale } = await params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.newYear.summary"),

--- a/app/[locale]/show/new-year-clock/layout.tsx
+++ b/app/[locale]/show/new-year-clock/layout.tsx
@@ -4,10 +4,6 @@ import type { ReactNode } from "react";
 
 import { createMetadata } from "@/shared/utils/metadata";
 
-// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 interface Props {
   children: ReactNode;
 }

--- a/app/[locale]/show/new-year-clock/page.tsx
+++ b/app/[locale]/show/new-year-clock/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import { Countdown } from "./countdown";
 
-// Cache Components opt-out — remove after this route is adopted.
+// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/new-year-clock">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.newYear.summary"),

--- a/app/[locale]/show/new-year-clock/page.tsx
+++ b/app/[locale]/show/new-year-clock/page.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { createMetadata } from "@/shared/utils/metadata";
 
 import { Countdown } from "./countdown";
-
-// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
@@ -21,13 +19,11 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-export default async function Page(
-  _props: PageProps<"/[locale]/show/new-year-clock">
-) {
+export default async function Page() {
   const t = await getTranslations();
 
   return (
-    <section className="showcase-page">
+    <section className="showcase-page" data-testid="showcase-detail-shell">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.newYear.description")}
@@ -39,7 +35,9 @@ export default async function Page(
         title={t("showcase.items.newYear.title")}
       />
 
-      <Countdown />
+      <Suspense fallback={<Skeleton className="h-40 w-full rounded-lg" />}>
+        <Countdown />
+      </Suspense>
     </section>
   );
 }

--- a/app/[locale]/show/page.tsx
+++ b/app/[locale]/show/page.tsx
@@ -1,21 +1,13 @@
 import type { Metadata } from "next";
 import Image from "next/image";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { LanguageSelector } from "@/components/language-selector";
 import { Link } from "@/shared/i18n/navigation";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.description"),

--- a/app/[locale]/show/page.tsx
+++ b/app/[locale]/show/page.tsx
@@ -79,7 +79,12 @@ export default async function Page(_props: PageProps<"/[locale]/show">) {
 
       <nav aria-label={t("showcase.projectsLabel")} className="showcase-list">
         {SHOWCASE_ITEMS.map(({ key, path }) => (
-          <Link className="showcase-item-link" href={path} key={path}>
+          <Link
+            className="showcase-item-link"
+            data-testid={`showcase-link-${key}`}
+            href={path}
+            key={path}
+          >
             <span className="showcase-item-top">
               <span className="showcase-item-title">
                 {t(`showcase.items.${key}.title`)}

--- a/app/[locale]/show/tech-stack-ball/page.tsx
+++ b/app/[locale]/show/tech-stack-ball/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import { PlaygroundWrapper } from "./playground-wrapper";
 
-// Cache Components opt-out — remove after this route is adopted.
+// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/tech-stack-ball">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.techStack.summary"),

--- a/app/[locale]/show/tech-stack-ball/page.tsx
+++ b/app/[locale]/show/tech-stack-ball/page.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { createMetadata } from "@/shared/utils/metadata";
 
 import { PlaygroundWrapper } from "./playground-wrapper";
-
-// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
@@ -21,13 +19,11 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-export default async function Page(
-  _props: PageProps<"/[locale]/show/tech-stack-ball">
-) {
+export default async function Page() {
   const t = await getTranslations();
 
   return (
-    <section className="showcase-page">
+    <section className="showcase-page" data-testid="showcase-detail-shell">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.techStack.description")}
@@ -39,11 +35,13 @@ export default async function Page(
         title={t("showcase.items.techStack.title")}
       />
 
-      <PlaygroundWrapper
-        className="rounded-none border-0 bg-transparent shadow-none"
-        h={400}
-        w={800}
-      />
+      <Suspense fallback={<Skeleton className="h-[400px] w-full rounded-lg" />}>
+        <PlaygroundWrapper
+          className="rounded-none border-0 bg-transparent shadow-none"
+          h={400}
+          w={800}
+        />
+      </Suspense>
     </section>
   );
 }

--- a/app/[locale]/show/unstructured-0828/page.tsx
+++ b/app/[locale]/show/unstructured-0828/page.tsx
@@ -1,24 +1,16 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import SaaSComponentImage from "./saas-component.png";
 import SaaSPageImage from "./saas-page.png";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/unstructured-0828">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.unstructured0828.summary"),

--- a/app/[locale]/show/unstructured/page.tsx
+++ b/app/[locale]/show/unstructured/page.tsx
@@ -1,22 +1,14 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 import { cn } from "@/shared/utils/tailwind";
 
 import styles from "./styles.module.css";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/unstructured">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.unstructured.summary"),

--- a/app/[locale]/show/yet-another-tempfiles/page.tsx
+++ b/app/[locale]/show/yet-another-tempfiles/page.tsx
@@ -1,14 +1,12 @@
 import type { Metadata } from "next";
 import { getLocale, getTranslations } from "next-intl/server";
+import { Suspense } from "react";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
+import { Skeleton } from "@/components/ui/skeleton";
 import { createMetadata } from "@/shared/utils/metadata";
 
 import TmpfUI from "./tmpf";
-
-// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
 
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
@@ -21,13 +19,11 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-export default async function Page(
-  _props: PageProps<"/[locale]/show/yet-another-tempfiles">
-) {
+export default async function Page() {
   const t = await getTranslations();
 
   return (
-    <section className="showcase-page">
+    <section className="showcase-page" data-testid="showcase-detail-shell">
       <ShowcaseDetailHeader
         backLabel={t("back")}
         description={t("showcase.items.tempfiles.description")}
@@ -40,7 +36,9 @@ export default async function Page(
       />
 
       <div className="rounded-lg border border-foreground/10 bg-secondary/25 p-5 sm:p-6">
-        <TmpfUI />
+        <Suspense fallback={<Skeleton className="h-48 w-full" />}>
+          <TmpfUI />
+        </Suspense>
       </div>
       <p className="mt-3 text-[0.6875rem] text-muted-foreground leading-relaxed">
         {t("showcase.items.tempfiles.notice")}

--- a/app/[locale]/show/yet-another-tempfiles/page.tsx
+++ b/app/[locale]/show/yet-another-tempfiles/page.tsx
@@ -1,21 +1,17 @@
 import type { Metadata } from "next";
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 
 import { ShowcaseDetailHeader } from "@/components/showcase-detail-header";
-import { createMetadata, resolveLocale } from "@/shared/utils/metadata";
+import { createMetadata } from "@/shared/utils/metadata";
 
 import TmpfUI from "./tmpf";
 
-// Cache Components opt-out — remove after this route is adopted.
+// Deliberate Block: client-only interaction (canvas / Date.now / Math.random / network).
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
 export const instant = false;
 
-export async function generateMetadata(
-  props: PageProps<"/[locale]/show/yet-another-tempfiles">
-): Promise<Metadata> {
-  const { locale: routeLocale } = await props.params;
-  const locale = resolveLocale(routeLocale);
-  const t = await getTranslations({ locale });
+export async function generateMetadata(): Promise<Metadata> {
+  const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 
   return createMetadata({
     description: t("showcase.items.tempfiles.summary"),

--- a/app/global-not-found.tsx
+++ b/app/global-not-found.tsx
@@ -8,10 +8,6 @@ import { createMetadata, getLocalizedPath } from "@/shared/utils/metadata";
 import "./globals.css";
 import { RootDocument } from "./root-document";
 
-// Cache Components opt-out — remove after this route is adopted.
-// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
-export const instant = false;
-
 export async function generateMetadata(): Promise<Metadata> {
   const [locale, t] = await Promise.all([getLocale(), getTranslations()]);
 

--- a/e2e/soft-nav.instant.spec.ts
+++ b/e2e/soft-nav.instant.spec.ts
@@ -1,0 +1,50 @@
+import { instant } from "@next/playwright";
+import { expect, test } from "@playwright/test";
+
+/**
+ * Soft-nav instant() guards. Run against a production build with
+ * EXPOSE_TESTING_API=1 (see instant-nav.rig.md). Public site — no auth.
+ */
+
+test.describe("instant soft-nav: home → blog", () => {
+  test("blog list shell commits under instant()", async ({ page }) => {
+    await page.goto("/");
+    const trigger = page.getByTestId("home-link-blog");
+    await expect(trigger).toBeVisible({ timeout: 20_000 });
+
+    await instant(page, async () => {
+      await trigger.click();
+      await expect(page.getByTestId("blog-list-shell")).toBeVisible();
+    });
+  });
+});
+
+test.describe("instant soft-nav: blog → post", () => {
+  test("blog post shell commits under instant()", async ({ page }) => {
+    await page.goto("/blog");
+    // Prefer an in-app post link (external_url posts open a new origin).
+    const trigger = page.locator('a[data-testid="blog-post-link"]').first();
+    await expect(trigger).toBeVisible({ timeout: 20_000 });
+
+    await instant(page, async () => {
+      await trigger.click();
+      await expect(page.getByTestId("blog-post-shell")).toBeVisible();
+    });
+  });
+});
+
+test.describe("instant soft-nav: show → tech-stack-ball", () => {
+  test("showcase shell commits under instant()", async ({ page }) => {
+    await page.goto("/show");
+    const trigger = page
+      .locator('a[href*="/show/tech-stack-ball"]')
+      .or(page.getByTestId("showcase-link-techStack"))
+      .first();
+    await expect(trigger).toBeVisible({ timeout: 20_000 });
+
+    await instant(page, async () => {
+      await trigger.click();
+      await expect(page.getByTestId("showcase-detail-shell")).toBeVisible();
+    });
+  });
+});

--- a/instant-nav.rig.md
+++ b/instant-nav.rig.md
@@ -1,0 +1,12 @@
+# instant-nav rig: minpeter.v2
+
+- BUILD: `EXPOSE_TESTING_API=1 pnpm build && pnpm start` (port 8200)
+- EXPOSE: `experimental.exposeTestingApiInProductionBuild` when `process.env.EXPOSE_TESTING_API === "1"` (`next.config.mts`)
+- RUN: `pnpm test:e2e` → Playwright against `http://127.0.0.1:8200` (or `BASE_URL`)
+- TEST USER: public site, no auth; default locale `ko` (`localePrefix: as-needed`)
+- DRIFT: locale cookie / path prefix (`/en`, `/ja`); content MDX set; portless host only for `pnpm dev` (not used for instant())
+- LOOP: build with EXPOSE → start → playwright test; fully local/agent-drivable
+- LIVENESS: n/a for local build && start (artifact is the one just built)
+- WALLS:
+  - Never measure on `pnpm dev` / portless — instant() needs production build + testing API
+  - Reuse port 8200 carefully; stop previous `next start` if `EADDRINUSE`

--- a/next.config.mts
+++ b/next.config.mts
@@ -7,6 +7,9 @@ import createNextIntlPlugin from "next-intl/plugin";
 const nextConfig: NextConfig = {
   cacheComponents: true,
   experimental: {
+    // Only for local/CI measured production builds used by @next/playwright instant().
+    // Never enable in real production deploys.
+    exposeTestingApiInProductionBuild: process.env.EXPOSE_TESTING_API === "1",
     globalNotFound: true,
     optimizePackageImports: [
       "lucide-react",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "postinstall": "fumadocs-mdx",
     "knip": "knip",
     "start": "next start -p 8200",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:instant": "EXPOSE_TESTING_API=1 pnpm build && playwright test"
   },
   "dependencies": {
     "@next/third-parties": "16.3.0",
@@ -54,6 +56,8 @@
     "@biomejs/biome": "2.5.6",
     "@edge-runtime/vm": "^5.0.0",
     "@next/bundle-analyzer": "16.3.0",
+    "@next/playwright": "16.3.0",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/postcss": "^4.3.3",
     "@testing-library/react": "^16.3.2",
     "@types/matter-js": "^0.20.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PORT ?? 8200);
+const baseURL = process.env.BASE_URL ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  forbidOnly: Boolean(process.env.CI),
+  fullyParallel: true,
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  reporter: process.env.CI ? "github" : "list",
+  retries: process.env.CI ? 1 : 0,
+  testDir: "./e2e",
+  timeout: 60_000,
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  // Assumes a production build is already running (see package.json test:e2e).
+  // EXPOSE_TESTING_API=1 must have been set during `next build`.
+  webServer: process.env.PLAYWRIGHT_SKIP_WEBSERVER
+    ? undefined
+    : {
+        command: "pnpm start",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        url: baseURL,
+      },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
     dependencies:
       '@next/third-parties':
         specifier: 16.3.0
-        version: 16.3.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@radix-ui/react-aspect-ratio':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -34,13 +34,13 @@ importers:
         version: 0.13.11(typescript@7.0.2)(zod@4.4.3)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/toolbar':
         specifier: ^0.2.7
-        version: 0.2.7(@vercel/analytics@2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.2.7(@vercel/analytics@2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       axios:
         specifier: 1.19.0
         version: 1.19.0(debug@4.4.3)
@@ -64,13 +64,13 @@ importers:
         version: 8.6.0(react@19.2.8)
       fumadocs-core:
         specifier: 16.14.1
-        version: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+        version: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 15.2.2
-        version: 15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.1.5)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.1.5)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       fumadocs-ui:
         specifier: 16.14.1
-        version: 16.14.1(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
+        version: 16.14.1(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3)
       lucide-react:
         specifier: ^1.29.0
         version: 1.29.0(react@19.2.8)
@@ -79,13 +79,13 @@ importers:
         version: 0.20.0
       next:
         specifier: 16.3.0
-        version: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl:
         specifier: ^4.13.5
-        version: 4.13.5(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
+        version: 4.13.5(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2)
       nuqs:
         specifier: ^2.9.5
-        version: 2.9.5(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.9.5(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -111,6 +111,12 @@ importers:
       '@next/bundle-analyzer':
         specifier: 16.3.0
         version: 16.3.0
+      '@next/playwright':
+        specifier: 16.3.0
+        version: 16.3.0(@playwright/test@1.62.1)
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@tailwindcss/postcss':
         specifier: ^4.3.3
         version: 4.3.3
@@ -143,7 +149,7 @@ importers:
         version: 6.32.0
       next-sitemap:
         specifier: ^4.2.3
-        version: 4.2.3(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 4.2.3(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -756,6 +762,14 @@ packages:
 
   '@next/env@16.3.0':
     resolution: {integrity: sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw==}
+
+  '@next/playwright@16.3.0':
+    resolution: {integrity: sha512-lYFQDfksErmwifriLvnuhywiTqKtC7faxbLQSO2cmsrfVJsXA0L3cV1IqsXu7lhA8bFOOAxyvNBTtYyzKdKDew==}
+    peerDependencies:
+      '@playwright/test': '>=1.0.0'
+    peerDependenciesMeta:
+      '@playwright/test':
+        optional: true
 
   '@next/swc-darwin-arm64@16.3.0':
     resolution: {integrity: sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==}
@@ -1388,6 +1402,11 @@ packages:
   '@parcel/watcher@2.6.0':
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -3100,6 +3119,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4097,6 +4121,16 @@ packages:
   pidtree@1.0.0:
     resolution: {integrity: sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   po-parser@2.1.1:
@@ -5203,6 +5237,10 @@ snapshots:
 
   '@next/env@16.3.0': {}
 
+  '@next/playwright@16.3.0(@playwright/test@1.62.1)':
+    optionalDependencies:
+      '@playwright/test': 1.62.1
+
   '@next/swc-darwin-arm64@16.3.0':
     optional: true
 
@@ -5227,9 +5265,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
 
-  '@next/third-parties@16.3.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@next/third-parties@16.3.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     dependencies:
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       third-party-capital: 1.0.20
 
@@ -5543,6 +5581,10 @@ snapshots:
       '@parcel/watcher-linux-x64-musl': 2.6.0
       '@parcel/watcher-win32-arm64': 2.6.0
       '@parcel/watcher-win32-x64': 2.6.0
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6416,12 +6458,12 @@ snapshots:
 
   '@ungap/structured-clone@1.3.3': {}
 
-  '@vercel/analytics@2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/analytics@2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
-  '@vercel/microfrontends@2.4.0(@vercel/analytics@2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vercel/microfrontends@2.4.0(@vercel/analytics@2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@next/env': 16.0.10
       '@types/md5': 2.3.6
@@ -6436,31 +6478,31 @@ snapshots:
       path-to-regexp: 6.3.0
       semver: 7.8.5
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      '@vercel/speed-insights': 2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@vercel/analytics': 2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@vercel/speed-insights': 2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vite: 8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - debug
 
-  '@vercel/speed-insights@2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
-  '@vercel/toolbar@0.2.7(@vercel/analytics@2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vercel/toolbar@0.2.7(@vercel/analytics@2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@tinyhttp/app': 1.3.0
-      '@vercel/microfrontends': 2.4.0(@vercel/analytics@2.0.1(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vercel/microfrontends': 2.4.0(@vercel/analytics@2.0.1(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(@vercel/speed-insights@2.0.0(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8))(debug@4.4.3)(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       chokidar: 3.6.0
       execa: 5.1.1
       find-up: 5.0.0
       get-port: 5.1.1
       strip-ansi: 6.0.1
     optionalDependencies:
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       vite: 8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -7020,10 +7062,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3):
+  fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3):
     dependencies:
       estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
@@ -7050,21 +7095,21 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/react': 19.2.18
       lucide-react: 1.29.0(react@19.2.8)
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.1.5)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  fumadocs-mdx@15.2.2(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(rolldown@1.1.5)(vite@8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      fumadocs-core: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       github-slugger: 2.0.0
       magic-string: 1.1.0
       mdast-util-mdx: 3.0.0
@@ -7083,14 +7128,14 @@ snapshots:
       '@types/mdast': 4.0.4
       '@types/mdx': 2.0.14
       '@types/react': 19.2.18
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       rolldown: 1.1.5
       vite: 8.1.3(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.14.1(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
+  fumadocs-ui@16.14.1(@types/mdx@2.0.14)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(fumadocs-core@16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(tailwindcss@4.3.3):
     dependencies:
       '@fuma-translate/react': 1.0.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@fumadocs/tailwind': 0.1.1(tailwindcss@4.3.3)
@@ -7106,7 +7151,7 @@ snapshots:
       '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       class-variance-authority: 0.7.1
       cnfast: 0.1.0
-      fumadocs-core: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
+      fumadocs-core: 16.14.1(@mdx-js/mdx@3.1.1)(@types/estree-jsx@1.0.5)(@types/hast@3.0.5)(@types/mdast@4.0.4)(@types/react@19.2.18)(lucide-react@1.29.0(react@19.2.8))(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(zod@4.4.3)
       lucide-react: 1.28.0(react@19.2.8)
       motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -7120,7 +7165,7 @@ snapshots:
     optionalDependencies:
       '@types/mdx': 2.0.14
       '@types/react': 19.2.18
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react-dom'
@@ -8062,14 +8107,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.5: {}
 
-  next-intl@4.13.5(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
+  next-intl@4.13.5(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(typescript@7.0.2):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.13
       '@parcel/watcher': 2.6.0
       '@swc/core': 1.15.47
       icu-minify: 4.13.5
       negotiator: 1.0.0
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-intl-swc-plugin-extractor: 4.13.5
       po-parser: 2.1.1
       react: 19.2.8
@@ -8079,20 +8124,20 @@ snapshots:
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  next-sitemap@4.2.3(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
+  next-sitemap@4.2.3(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 13.5.11
       fast-glob: 3.3.3
       minimist: 1.2.8
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.3.0
       '@swc/helpers': 0.5.15
@@ -8111,6 +8156,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.3.0
       '@next/swc-win32-arm64-msvc': 16.3.0
       '@next/swc-win32-x64-msvc': 16.3.0
+      '@playwright/test': 1.62.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.35.3(@types/node@26.1.2)
     transitivePeerDependencies:
@@ -8141,12 +8187,12 @@ snapshots:
 
   npm-to-yarn@3.2.0: {}
 
-  nuqs@2.9.5(next@16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  nuqs@2.9.5(next@16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
     dependencies:
       '@standard-schema/spec': 1.1.0
       react: 19.2.8
     optionalDependencies:
-      next: 16.3.0(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.3.0(@playwright/test@1.62.1)(@types/node@26.1.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
   nypm@0.6.9:
     dependencies:
@@ -8328,6 +8374,14 @@ snapshots:
   picomatch@4.0.5: {}
 
   pidtree@1.0.0: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   po-parser@2.1.1: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,4 +19,3 @@ export default defineConfig({
     },
   },
 });
-

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
   },
   test: {
     environment: "node",
+    // Playwright e2e lives under e2e/ and is not for Vitest.
+    exclude: ["**/node_modules/**", "**/e2e/**", "**/dist/**", "**/.next/**"],
     globals: true,
     server: {
       deps: {
@@ -17,3 +19,4 @@ export default defineConfig({
     },
   },
 });
+


### PR DESCRIPTION
## Summary
Continues after #92 / #94:

### Deprecations / i18n
- Server Components prefer `getLocale()` + `getTranslations()` (no `{ locale }` override)
- Keep explicit locale for OG images + footer prop path
- AGENTS.md: experimental flags inventory + Route Handler locale override pattern

### Cache Components / soft-nav
- Remove `instant = false` from layout, home, resume, blog list/post, not-found, static showcase pages
- **Deliberate Blocks** remain for interactive showcases (canvas / timers / network)
- Blog list: server list in shell; client `BlogList` only handles search and swaps list when `?q=` is set
- Post route already has dedicated `loading.tsx`

## Test plan
- [x] `pnpm check:lint` / `check:types` / `test` / `build`
- [ ] Soft-nav: home → blog → post (shell + post loading, not list skeleton)
- [ ] Blog search `?q=` still filters
- [ ] Locale switcher + showcase interactive pages still work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adopts Cache Components shells across `[locale]` routes, removes remaining deprecations, and adds `instant()` soft‑nav e2e to verify instant shells. Migrates i18n to `getLocale()`/`getTranslations()`, streams blog post bodies with a Suspense split, keeps a server-rendered blog list, and wraps showcases in Suspense.

- **Refactors**
  - Removed `instant = false` from layout, home, resume, blog, not‑found, and static showcase pages; replaced showcase Blocks with Suspense fallbacks around client islands.
  - Blog post: split `PostBody` inside `<Suspense>` to stream URL-specific body; dedicated `loading.tsx`; added `data-testid` for shell/content; updated unit tests to import `PostBody`.
  - Blog list: server renders the full list filtered by locale; `BlogList` owns `?q=` and accepts `children` to keep the server list until searching; added `data-testid` on the list shell and post links.
  - i18n: Server Components and `generateMetadata` use `getLocale()` + `getTranslations()` (no `{ locale }` override). Keep explicit `{ locale }` for opengraph-image/twitter-image and Route Handlers.
  - Soft‑nav e2e: added `@next/playwright`, `playwright.config.ts`, and `e2e/soft-nav.instant.spec.ts`; expose testing API only when `EXPOSE_TESTING_API=1`. Added home/showcase link testids. Updated `.gitignore` and docs (`AGENTS.md`, `instant-nav.rig.md`).
  - Tests: mock `getLocale`; await Suspense in post tests; Vitest excludes `e2e/`.

- **Migration**
  - For lists, keep a server-rendered shell; limit client islands to interactions like search.
  - In Route Handlers/Server Actions, pass `{ locale }` explicitly; `next/root-params` is not reliable there.
  - Ensure `cacheComponents: true` and `partialPrefetching: true` in `next.config.mts`; testing API is gated by `EXPOSE_TESTING_API=1`.
  - For `instant()` e2e, build with `EXPOSE_TESTING_API=1` then run Playwright (`pnpm test:e2e:instant`).

<sup>Written for commit 4d00a128907d2924e0c292060c2c025f023a0ac9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/minpeter/minpeter.v2/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

